### PR TITLE
Additional Appearance Customization

### DIFF
--- a/JTCalendar/JTCalendarAppearance.h
+++ b/JTCalendar/JTCalendarAppearance.h
@@ -58,6 +58,13 @@ typedef NSString *(^JTCalendarMonthBlock)(NSDate *date, JTCalendar *jt_calendar)
 
 @property (strong, nonatomic) UIFont *dayTextFont;
 
+@property (strong, nonatomic) NSString *dayFormat;
+
+// Day Background and Border
+@property (strong, nonatomic) UIColor *dayBackgroundColor;
+@property (assign, nonatomic) CGFloat dayBorderWidth;
+@property (assign, nonatomic) UIColor *dayBorderColor;
+
 @property (assign, nonatomic) CGFloat dayCircleRatio;
 @property (assign, nonatomic) CGFloat dayDotRatio;
 

--- a/JTCalendar/JTCalendarAppearance.m
+++ b/JTCalendar/JTCalendarAppearance.m
@@ -40,6 +40,13 @@
     self.menuMonthTextFont = [UIFont systemFontOfSize:17.];
     self.weekDayTextFont = [UIFont systemFontOfSize:11];
     self.dayTextFont = [UIFont systemFontOfSize:[UIFont systemFontSize]];
+
+    self.dayFormat = @"dd";
+
+    // Day Background and Border
+    self.dayBackgroundColor = [UIColor clearColor];
+    self.dayBorderWidth = 0.0f;
+    self.dayBorderColor = [UIColor clearColor];
     
     self.menuMonthTextColor = [UIColor blackColor];
     self.weekDayTextColor = [UIColor colorWithRed:152./256. green:147./256. blue:157./256. alpha:1.];

--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -10,6 +10,7 @@
 #import "JTCircleView.h"
 
 @interface JTCalendarDayView (){
+    UIView *backgroundView;
     JTCircleView *circleView;
     UILabel *textLabel;
     JTCircleView *dotView;
@@ -58,6 +59,11 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
 {
     isSelected = NO;
     self.isOtherMonth = NO;
+
+    {
+        backgroundView = [UIView new];
+        [self addSubview:backgroundView];
+    }
     
     {
         circleView = [JTCircleView new];
@@ -98,7 +104,9 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
 - (void)configureConstraintsForSubviews
 {
     textLabel.frame = CGRectMake(0, 0, self.frame.size.width, self.frame.size.height);
-    
+    backgroundView.frame = CGRectMake(0, 0, self.frame.size.width, self.frame.size.height);
+
+
     CGFloat sizeCircle = MIN(self.frame.size.width, self.frame.size.height);
     CGFloat sizeDot = sizeCircle;
     
@@ -123,7 +131,7 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
     if(!dateFormatter){
         dateFormatter = [NSDateFormatter new];
         dateFormatter.timeZone = self.calendarManager.calendarAppearance.calendar.timeZone;
-        [dateFormatter setDateFormat:@"dd"];
+        [dateFormatter setDateFormat:self.calendarManager.calendarAppearance.dayFormat];
     }
     
     self->_date = date;
@@ -305,6 +313,9 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
 {
     textLabel.textAlignment = NSTextAlignmentCenter;
     textLabel.font = self.calendarManager.calendarAppearance.dayTextFont;
+    backgroundView.backgroundColor = self.calendarManager.calendarAppearance.dayBackgroundColor;
+    backgroundView.layer.borderWidth = self.calendarManager.calendarAppearance.dayBorderWidth;
+    backgroundView.layer.borderColor = self.calendarManager.calendarAppearance.dayBorderColor.CGColor;
     
     [self configureConstraintsForSubviews];
     [self setSelected:isSelected animated:NO];


### PR DESCRIPTION
I ran into a couple of use cases that I need for a app that I am working on.
1. Ability to change day formatting. In my case I needed to remove the leading 0 - "1" instead of "01".
2. Ability to have a background on each day and a border between each day.

I have implemented these changes using the JTCalendarAppearance that you already had created so each element is customizable. I did have to add a additional UIView for the background. By default everything is assigned a clear color value so it should not effect any previous implementation.

Below is a screen shot of the before and after of my changes.
Before:
![screen shot 2014-12-31 at 4 09 33 pm](https://cloud.githubusercontent.com/assets/3507007/5590855/83fd4bbe-9107-11e4-86df-5246a5a9b082.png)

After:
![screen shot 2014-12-31 at 4 09 56 pm](https://cloud.githubusercontent.com/assets/3507007/5590857/8d74ae26-9107-11e4-8cf5-c256ee34f274.png)
