### PR TITLE
Appearance & data source protocol additions

### DIFF
--- a/Example/Example/ViewController.m
+++ b/Example/Example/ViewController.m
@@ -6,6 +6,7 @@
 //
 
 #import "ViewController.h"
+#import "JTCalendarDayView.h"
 
 @interface ViewController (){
     NSMutableDictionary *eventsByDate;
@@ -49,6 +50,21 @@
             
             return [NSString stringWithFormat:@"%ld\n%@", comps.year, monthText];
         };
+
+        // Display a 'fill-box' behind each day showing percentage of events for that day
+//        self.calendar.calendarAppearance.dayViewBlock = ^(JTCalendarDayView *dayView, NSUInteger numberOfEvents) {
+//            [[dayView viewWithTag:7777] removeFromSuperview];
+//
+//            if (numberOfEvents == 0) {
+//                return;
+//            }
+//
+//            CGFloat height = dayView.bounds.size.height * fminf((numberOfEvents / 2.0f), 1.0f);
+//            UIView *boxFill = [[UIView alloc] initWithFrame:CGRectMake(0.0f, dayView.bounds.size.height - height, dayView.bounds.size.width, height)];
+//            boxFill.tag = 7777;
+//            boxFill.backgroundColor = [[UIColor lightGrayColor] colorWithAlphaComponent:0.2f];
+//            [dayView insertSubview:boxFill atIndex:0];
+//        };
     }
     
     [self.calendar setMenuMonthsView:self.calendarMenuView];
@@ -87,15 +103,11 @@
 
 #pragma mark - JTCalendarDataSource
 
-- (BOOL)calendarHaveEvent:(JTCalendar *)calendar date:(NSDate *)date
-{
+- (NSUInteger)calendarNumberOfEvents:(JTCalendar *)calendar date:(NSDate *)date {
+
     NSString *key = [[self dateFormatter] stringFromDate:date];
     
-    if(eventsByDate[key] && [eventsByDate[key] count] > 0){
-        return YES;
-    }
-    
-    return NO;
+    return (eventsByDate[key]) ? [eventsByDate[key] count] : 0;
 }
 
 - (void)calendarDidDateSelected:(JTCalendar *)calendar date:(NSDate *)date

--- a/JTCalendar/JTCalendarAppearance.h
+++ b/JTCalendar/JTCalendarAppearance.h
@@ -8,6 +8,7 @@
 #import <UIKit/UIKit.h>
 
 @class JTCalendar;
+@class JTCalendarDayView;
 
 @interface JTCalendarAppearance : NSObject
 
@@ -18,6 +19,7 @@ typedef NS_ENUM(NSInteger, JTCalendarWeekDayFormat) {
 };
 
 typedef NSString *(^JTCalendarMonthBlock)(NSDate *date, JTCalendar *jt_calendar);
+typedef void(^JTCalendarDayViewBlock)(JTCalendarDayView *dayView, NSUInteger numberOfEvents);
 
 @property (assign, nonatomic) BOOL isWeekMode;
 @property (assign, nonatomic) BOOL useCacheSystem;
@@ -43,6 +45,7 @@ typedef NSString *(^JTCalendarMonthBlock)(NSDate *date, JTCalendar *jt_calendar)
 @property (strong, nonatomic) UIColor *dayCircleColorToday;
 @property (strong, nonatomic) UIColor *dayCircleColorTodayOtherMonth;
 
+@property (assign, nonatomic) BOOL dayDotHidden;
 @property (strong, nonatomic) UIColor *dayDotColor;
 @property (strong, nonatomic) UIColor *dayDotColorSelected;
 @property (strong, nonatomic) UIColor *dayDotColorOtherMonth;
@@ -68,6 +71,8 @@ typedef NSString *(^JTCalendarMonthBlock)(NSDate *date, JTCalendar *jt_calendar)
 
 @property (assign, nonatomic) CGFloat dayCircleRatio;
 @property (assign, nonatomic) CGFloat dayDotRatio;
+
+@property (nonatomic, copy) JTCalendarDayViewBlock dayViewBlock;
 
 - (NSCalendar *)calendar;
 

--- a/JTCalendar/JTCalendarAppearance.m
+++ b/JTCalendar/JTCalendarAppearance.m
@@ -8,6 +8,7 @@
 #import "JTCalendarAppearance.h"
 
 #import "JTCalendar.h"
+#import "JTCalendarDayView.h"
 
 @implementation JTCalendarAppearance
 
@@ -36,6 +37,7 @@
     
     self.dayCircleRatio = 1.;
     self.dayDotRatio = 1. / 9.;
+    self.dayDotHidden = NO;
     
     self.menuMonthTextFont = [UIFont systemFontOfSize:17.];
     self.weekDayTextFont = [UIFont systemFontOfSize:11];
@@ -88,6 +90,10 @@
         }
         
         return [[dateFormatter standaloneMonthSymbols][currentMonthIndex - 1] capitalizedString];
+    };
+
+    self.dayViewBlock = ^(JTCalendarDayView *dayView, NSUInteger numberOfEvents) {
+        // no default customisation of day view
     };
 }
 

--- a/JTCalendar/JTCalendarDataCache.h
+++ b/JTCalendar/JTCalendarDataCache.h
@@ -14,6 +14,6 @@
 @property (weak, nonatomic) JTCalendar *calendarManager;
 
 - (void)reloadData;
-- (BOOL)haveEvent:(NSDate *)date;
+- (NSUInteger)numberOfEvents:(NSDate *)date;
 
 @end

--- a/JTCalendar/JTCalendarDataCache.m
+++ b/JTCalendar/JTCalendarDataCache.m
@@ -37,28 +37,41 @@
     [events removeAllObjects];
 }
 
-- (BOOL)haveEvent:(NSDate *)date
+- (NSUInteger)numberOfEvents:(NSDate *)date
 {
     if(!self.calendarManager.dataSource){
         return NO;
     }
     
-    if(!self.calendarManager.calendarAppearance.useCacheSystem){
-        return [self.calendarManager.dataSource calendarHaveEvent:self.calendarManager date:date];
+    if (!self.calendarManager.calendarAppearance.useCacheSystem) {
+        if ([self.calendarManager.dataSource respondsToSelector:@selector(calendarNumberOfEvents:date:)]) {
+            return [self.calendarManager.dataSource calendarNumberOfEvents:self.calendarManager date:date];
+        } else if ([self.calendarManager.dataSource respondsToSelector:@selector(calendarHaveEvent:date:)]) {
+            return [self.calendarManager.dataSource calendarHaveEvent:self.calendarManager date:date] ? 1 : 0;
+        } else {
+            return NO;
+        }
     }
     
-    BOOL haveEvent;
+    NSUInteger numberOfEvents;
     NSString *key = [dateFormatter stringFromDate:date];
     
     if(events[key] != nil){
-        haveEvent = [events[key] boolValue];
+        numberOfEvents = [events[key] unsignedIntegerValue];
     }
     else{
-        haveEvent = [self.calendarManager.dataSource calendarHaveEvent:self.calendarManager date:date];
-        events[key] = [NSNumber numberWithBool:haveEvent];
+        if ([self.calendarManager.dataSource respondsToSelector:@selector(calendarNumberOfEvents:date:)]) {
+            numberOfEvents = [self.calendarManager.dataSource calendarNumberOfEvents:self.calendarManager date:date];
+        } else if ([self.calendarManager.dataSource respondsToSelector:@selector(calendarHaveEvent:date:)]) {
+            numberOfEvents = [self.calendarManager.dataSource calendarHaveEvent:self.calendarManager date:date] ? 1 : 0;
+        } else {
+            numberOfEvents = 0;
+        }
+
+        events[key] = @(numberOfEvents);
     }
     
-    return haveEvent;
+    return numberOfEvents;
 }
 
 @end

--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -254,7 +254,13 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
 
 - (void)reloadData
 {
-    dotView.hidden = ![self.calendarManager.dataCache haveEvent:self.date];
+    NSUInteger numberOfEvents = [self.calendarManager.dataCache numberOfEvents:self.date];
+
+    dotView.hidden = (self.calendarManager.calendarAppearance.dayDotHidden) || (numberOfEvents == 0);
+
+    if (self.calendarManager.calendarAppearance.dayViewBlock) {
+        self.calendarManager.calendarAppearance.dayViewBlock(self, numberOfEvents);
+    }
     
     BOOL selected = [self isSameDate:[self.calendarManager currentDateSelected]];
     [self setSelected:selected animated:NO];

--- a/JTCalendar/JTCalendarViewDataSource.h
+++ b/JTCalendar/JTCalendarViewDataSource.h
@@ -11,7 +11,21 @@
 
 @protocol JTCalendarDataSource <NSObject>
 
-- (BOOL)calendarHaveEvent:(JTCalendar *)calendar date:(NSDate *)date;
+/**
+ * Called to determine whether to show the 'day dot' for a particular date.
+ * Note: This method is deprecated. Use `calendarNumberOfEvents` instead.
+ */
+- (BOOL)calendarHaveEvent:(JTCalendar *)calendar date:(NSDate *)date __deprecated;
+
+/**
+ * Called to determine whether the show the 'day dot' for a particular date.
+ * Anything about 0 will show the day dot.
+ */
+- (NSUInteger)calendarNumberOfEvents:(JTCalendar *)calendar date:(NSDate *)date;
+
+/**
+ * Callback when a particular date is selected
+ */
 - (void)calendarDidDateSelected:(JTCalendar *)calendar date:(NSDate *)date;
 
 @optional

--- a/JTCalendar/JTCalendarViewDataSource.h
+++ b/JTCalendar/JTCalendarViewDataSource.h
@@ -15,6 +15,7 @@
  * Called to determine whether to show the 'day dot' for a particular date.
  * Note: This method is deprecated. Use `calendarNumberOfEvents` instead.
  */
+@optional
 - (BOOL)calendarHaveEvent:(JTCalendar *)calendar date:(NSDate *)date __deprecated;
 
 /**

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Your UIViewController must implement `JTCalendarDataSource`
     [self.calendar reloadData]; // Must be call in viewDidAppear
 }
 
-- (BOOL)calendarHaveEvent:(JTCalendar *)calendar date:(NSDate *)date
+- (NSUInteger)calendarNumberOfEvents:(JTCalendar *)calendar date:(NSDate *)date
 {
-    return NO;
+    return 1;
 }
 
 - (void)calendarDidDateSelected:(JTCalendar *)calendar date:(NSDate *)date


### PR DESCRIPTION
Excellent calendar - thanks!

I ran into a couple of customisations for an app I'm working on.

The base requirement was to show 'fill-box' behind each day, showing how many events for a particular day (i.e. if there are 8 events, the box would be 100% full, 4 events, 50% full etc).

In order to support that, I've added a new data source protocol to return the number of events for a date, and deprecated the existing hasEvent protocol. A day with 1 or more events will show the day dot. I made some selector checks so existing code bases will still work with the old method.

I've also added two new appearance customisation - one to toggle displaying the day dot at all (i.e. always hidden), and another for a callback block to customise the `JTCalendarDayView` for each view. This allows me to inject the 'fill-box' views for each day.

The example fill-box code is commented out in the Example ViewController as a handy reference for people looking for a similar customisation.

End result is something like this:

![screen shot 2015-02-21 at 8 31 01 am](https://cloud.githubusercontent.com/assets/409207/6310648/ba43adba-b9a4-11e4-80cb-3505009cf785.png)
