### PR TITLE
dotColor Delegate for changing color based on Date

### DIFF
--- a/Example/Example/ViewController.m
+++ b/Example/Example/ViewController.m
@@ -87,6 +87,17 @@
 
 #pragma mark - JTCalendarDataSource
 
+- (UIColor *)colorForDot:(JTCalendar *)calendar date:(NSDate *)date defaultDotColor:(UIColor *)defaultColor {
+    
+    NSString *key = [[self dateFormatter] stringFromDate:date];
+
+    if(eventsByDate[key] && [eventsByDate[key] count] > 1){
+        return [UIColor yellowColor];
+    }
+
+    return defaultColor;
+}
+
 - (BOOL)calendarHaveEvent:(JTCalendar *)calendar date:(NSDate *)date
 {
     NSString *key = [[self dateFormatter] stringFromDate:date];

--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -198,12 +198,12 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
         if(!self.isOtherMonth){
             circleView.color = [self.calendarManager.calendarAppearance dayCircleColorSelected];
             textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorSelected];
-            dotView.color = [self.calendarManager.calendarAppearance dayDotColorSelected];
+            dotView.color = [self dotColorFromDelegateOrDefaultColor:[self.calendarManager.calendarAppearance dayDotColorSelected]];
         }
         else{
             circleView.color = [self.calendarManager.calendarAppearance dayCircleColorSelectedOtherMonth];
             textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorSelectedOtherMonth];
-            dotView.color = [self.calendarManager.calendarAppearance dayDotColorSelectedOtherMonth];
+            dotView.color = [self dotColorFromDelegateOrDefaultColor:[self.calendarManager.calendarAppearance dayDotColorSelectedOtherMonth]];
         }
         
         circleView.transform = CGAffineTransformScale(CGAffineTransformIdentity, 0.1, 0.1);
@@ -213,22 +213,22 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
         if(!self.isOtherMonth){
             circleView.color = [self.calendarManager.calendarAppearance dayCircleColorToday];
             textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorToday];
-            dotView.color = [self.calendarManager.calendarAppearance dayDotColorToday];
+            dotView.color = [self dotColorFromDelegateOrDefaultColor:[self.calendarManager.calendarAppearance dayDotColorToday]];
         }
         else{
             circleView.color = [self.calendarManager.calendarAppearance dayCircleColorTodayOtherMonth];
             textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorTodayOtherMonth];
-            dotView.color = [self.calendarManager.calendarAppearance dayDotColorTodayOtherMonth];
+            dotView.color = [self dotColorFromDelegateOrDefaultColor:[self.calendarManager.calendarAppearance dayDotColorTodayOtherMonth]];
         }
     }
     else{
         if(!self.isOtherMonth){
             textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColor];
-            dotView.color = [self.calendarManager.calendarAppearance dayDotColor];
+            dotView.color = [self dotColorFromDelegateOrDefaultColor:[self.calendarManager.calendarAppearance dayDotColor]];
         }
         else{
             textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorOtherMonth];
-            dotView.color = [self.calendarManager.calendarAppearance dayDotColorOtherMonth];
+            dotView.color = [self dotColorFromDelegateOrDefaultColor:[self.calendarManager.calendarAppearance dayDotColorOtherMonth]];
         }
         
         opacity = 0.;
@@ -244,6 +244,17 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
         circleView.layer.opacity = opacity;
         circleView.transform = tr;
     }
+}
+
+- (UIColor *)dotColorFromDelegateOrDefaultColor:(UIColor *)defaultDotColor {
+    
+    UIColor *dotColor = defaultDotColor;
+    
+    if ([self.calendarManager.dataSource respondsToSelector:@selector(colorForDot:date:defaultDotColor:)]) {
+        dotColor = [self.calendarManager.dataSource colorForDot:self.calendarManager date:self.date defaultDotColor:defaultDotColor];
+    }
+    
+    return dotColor;
 }
 
 - (void)setIsOtherMonth:(BOOL)isOtherMonth

--- a/JTCalendar/JTCalendarViewDataSource.h
+++ b/JTCalendar/JTCalendarViewDataSource.h
@@ -15,6 +15,7 @@
 - (void)calendarDidDateSelected:(JTCalendar *)calendar date:(NSDate *)date;
 
 @optional
+- (UIColor *)colorForDot:(JTCalendar *)calendar date:(NSDate *)date defaultDotColor:(UIColor *)defaultColor;
 - (void)calendarDidLoadPreviousPage;
 - (void)calendarDidLoadNextPage;
 


### PR DESCRIPTION
Ability to change the dot color based on the specific date.  The use case is where you may want to have different dot colors based on the information for that date. For example, we use it to show that you have gone over hours on projects for the day..