### PR TITLE
Added support for picking up a range of dates in the calendar

### DIFF
--- a/Example/Example/Base.lproj/Main.storyboard
+++ b/Example/Example/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1510" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6736"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -32,8 +32,8 @@
                                     <constraint firstAttribute="height" constant="300" id="Kfn-Ge-jpQ"/>
                                 </constraints>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tAZ-Js-Lak">
-                                <rect key="frame" x="30" y="439" width="108" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tAZ-Js-Lak">
+                                <rect key="frame" x="46" y="400" width="41" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="IKB-he-ALt"/>
                                 </constraints>
@@ -44,8 +44,8 @@
                                     <action selector="didGoTodayTouch" destination="vXZ-lx-hvc" eventType="touchUpInside" id="VSR-WY-P5H"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m6a-lR-Xrr">
-                                <rect key="frame" x="438" y="439" width="116" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m6a-lR-Xrr">
+                                <rect key="frame" x="457" y="400" width="97" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="v0J-jr-NiI"/>
                                 </constraints>
@@ -54,6 +54,24 @@
                                 </state>
                                 <connections>
                                     <action selector="didChangeModeTouch" destination="vXZ-lx-hvc" eventType="touchUpInside" id="uEc-Nc-0ds"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0BA-2b-2NK">
+                                <rect key="frame" x="16" y="470" width="118" height="30"/>
+                                <state key="normal" title="Range Start Date">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="pickRangeStartDate:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="xZL-7I-EcE"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tKy-gG-l5s">
+                                <rect key="frame" x="472" y="470" width="112" height="30"/>
+                                <state key="normal" title="Range End Date">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="pickRangeEndDate:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="VWm-pK-VCa"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -66,6 +84,7 @@
                             <constraint firstAttribute="trailing" secondItem="IaV-x3-ghF" secondAttribute="trailing" id="ILA-fg-kaE"/>
                             <constraint firstItem="tAZ-Js-Lak" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leadingMargin" constant="30" id="Il1-mE-TXp"/>
                             <constraint firstItem="m6a-lR-Xrr" firstAttribute="top" secondItem="IaV-x3-ghF" secondAttribute="bottom" constant="30" id="JGt-zH-o6k"/>
+                            <constraint firstItem="tKy-gG-l5s" firstAttribute="top" secondItem="m6a-lR-Xrr" secondAttribute="bottom" constant="40" id="PG3-dz-vr3"/>
                             <constraint firstItem="IaV-x3-ghF" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="PYk-FM-FXS"/>
                             <constraint firstAttribute="trailingMargin" secondItem="IaV-x3-ghF" secondAttribute="trailing" id="PvC-p0-iWl"/>
                             <constraint firstItem="bLk-nx-MCc" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leadingMargin" id="Rd4-Q9-L4E"/>
@@ -76,8 +95,11 @@
                             <constraint firstAttribute="trailing" secondItem="bLk-nx-MCc" secondAttribute="trailing" id="asl-i5-V9P"/>
                             <constraint firstItem="IaV-x3-ghF" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="cFY-Hs-lva"/>
                             <constraint firstAttribute="trailing" secondItem="IaV-x3-ghF" secondAttribute="trailing" id="d19-oL-lkX"/>
+                            <constraint firstItem="0BA-2b-2NK" firstAttribute="top" secondItem="tAZ-Js-Lak" secondAttribute="bottom" constant="40" id="mEL-2D-8nm"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="tKy-gG-l5s" secondAttribute="trailing" id="oqd-hS-hwb"/>
                             <constraint firstItem="IaV-x3-ghF" firstAttribute="top" secondItem="bLk-nx-MCc" secondAttribute="bottom" id="rX7-ap-Tfe"/>
                             <constraint firstAttribute="trailing" secondItem="bLk-nx-MCc" secondAttribute="trailing" id="sT1-xO-UwV"/>
+                            <constraint firstItem="0BA-2b-2NK" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leadingMargin" id="wEY-xS-7T4"/>
                             <constraint firstAttribute="trailingMargin" secondItem="m6a-lR-Xrr" secondAttribute="trailing" constant="30" id="yXq-gU-Nbf"/>
                         </constraints>
                         <variation key="default">
@@ -97,6 +119,8 @@
                         <outlet property="calendarContentView" destination="IaV-x3-ghF" id="VFE-26-7W4"/>
                         <outlet property="calendarContentViewHeight" destination="Kfn-Ge-jpQ" id="r4i-aV-g9Y"/>
                         <outlet property="calendarMenuView" destination="bLk-nx-MCc" id="exp-NN-C52"/>
+                        <outlet property="rangeEndDate" destination="tKy-gG-l5s" id="bL3-oZ-Lnd"/>
+                        <outlet property="rangeStartDate" destination="0BA-2b-2NK" id="LQb-xu-LMT"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>

--- a/Example/Example/ViewController.h
+++ b/Example/Example/ViewController.h
@@ -9,7 +9,7 @@
 
 #import "JTCalendar.h"
 
-@interface ViewController : UIViewController<JTCalendarDataSource>
+@interface ViewController : UIViewController<JTCalendarDataSource, JTCalendarDateRangeDelegate>
 
 @property (weak, nonatomic) IBOutlet JTCalendarMenuView *calendarMenuView;
 @property (weak, nonatomic) IBOutlet JTCalendarContentView *calendarContentView;

--- a/Example/Example/ViewController.m
+++ b/Example/Example/ViewController.m
@@ -9,6 +9,8 @@
 
 @interface ViewController (){
     NSMutableDictionary *eventsByDate;
+    __weak IBOutlet UIButton *rangeStartDate;
+    __weak IBOutlet UIButton *rangeEndDate;
 }
 
 @end
@@ -28,7 +30,6 @@
         self.calendar.calendarAppearance.dayCircleRatio = 9. / 10.;
         self.calendar.calendarAppearance.ratioContentMenu = 2.;
         self.calendar.calendarAppearance.focusSelectedDayChangeMode = YES;
-        
         // Customize the text for each month
         self.calendar.calendarAppearance.monthBlock = ^NSString *(NSDate *date, JTCalendar *jt_calendar){
             NSCalendar *calendar = jt_calendar.calendarAppearance.calendar;
@@ -54,6 +55,7 @@
     [self.calendar setMenuMonthsView:self.calendarMenuView];
     [self.calendar setContentView:self.calendarContentView];
     [self.calendar setDataSource:self];
+    [self.calendar setDateRangeDelegate:self];
     
     [self createRandomEvents];
     
@@ -79,6 +81,24 @@
     [self transitionExample];
 }
 
+- (IBAction)pickRangeStartDate:(id)sender {
+    [rangeStartDate setSelected:!rangeStartDate.selected];
+    [rangeEndDate setSelected:NO];
+    [self resetRangeIfNeeded];
+}
+
+- (IBAction)pickRangeEndDate:(id)sender {
+    [rangeEndDate setSelected:!rangeEndDate.selected];
+    [rangeStartDate setSelected:NO];
+    [self resetRangeIfNeeded];
+}
+
+- (void)resetRangeIfNeeded {
+    if (!rangeStartDate.selected && !rangeEndDate.selected) {
+        [self.calendar setStartDateInRange:nil];
+        [self.calendar setEndDateInRange:nil];
+    }
+}
 #pragma mark - JTCalendarDataSource
 
 - (BOOL)calendarHaveEvent:(JTCalendar *)calendar date:(NSDate *)date
@@ -98,6 +118,12 @@
     NSArray *events = eventsByDate[key];
     
     NSLog(@"Date: %@ - %ld events", date, [events count]);
+    
+    if (rangeStartDate.selected) {
+        [self.calendar setStartDateInRange:date];
+    } else if (rangeEndDate.selected) {
+        [self.calendar setEndDateInRange:date];
+    }
 }
 
 - (void)calendarDidLoadPreviousPage
@@ -108,6 +134,35 @@
 - (void)calendarDidLoadNextPage
 {
     NSLog(@"Next page loaded");
+}
+
+#pragma mark - JTCalendarDateRangeDelegate
+- (void)styleDayBackgroundView:(UIView *)backgroundView forDateInRange:(JTCalendarDateRange)dateRange {
+    [backgroundView.layer setBorderColor:[UIColor whiteColor].CGColor];
+    [backgroundView.layer setBorderWidth:0.5f];
+    UIColor *colorForDatesInRange = [UIColor colorWithRed:251.f/255.f green:77.f/255.f blue:0.f/255.f alpha:0.3f];
+    switch (dateRange) {
+        case JTCalendarDateRangeBeginDate:
+            [backgroundView setBackgroundColor:colorForDatesInRange];
+            break;
+        case JTCalendarDateRangeMiddleDate:
+            [backgroundView setBackgroundColor:colorForDatesInRange];
+            break;
+        case JTCalendarDateRangeEndDate:
+            [backgroundView setBackgroundColor:colorForDatesInRange];
+            break;
+        case JTCalendarDateAfterRange:
+            [backgroundView setBackgroundColor:[UIColor clearColor]];
+            break;
+        case JTCalendarDateBeforeRange:
+            [backgroundView setBackgroundColor:[UIColor lightGrayColor]];
+            break;
+        case JTCalendarDateNoRangeSelected:
+            [backgroundView setBackgroundColor:[UIColor clearColor]];
+            break;
+        default:
+            break;
+    }
 }
 
 #pragma mark - Transition examples

--- a/JTCalendar.podspec
+++ b/JTCalendar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "JTCalendar"
-  s.version      = "1.2.0"
+  s.version      = "1.2.1"
   s.summary      = "A customizable calendar view for iOS."
   s.homepage     = "https://github.com/jonathantribouharet/JTCalendar"
   s.license      = { :type => 'MIT' }

--- a/JTCalendar/JTCalendar.h
+++ b/JTCalendar/JTCalendar.h
@@ -43,6 +43,6 @@
 
 - (void)repositionViews;
 
-- (JTCalendarDateRange)dateBelongsToSelectedRange:(NSDate *)date;
+- (JTCalendarDateRange)dateStatusInRange:(NSDate *)date;
 - (BOOL)calendarIsUsingRangeOfDates;
 @end

--- a/JTCalendar/JTCalendar.h
+++ b/JTCalendar/JTCalendar.h
@@ -43,6 +43,13 @@
 
 - (void)repositionViews;
 
+/**
+ *  Returns the JTCalendarDateRange representing the date in the range
+ *  If range has no startDate, it will consider it as Today
+ *  @param date the date to check in current range
+ *
+ *  @return the JTCalendarDateRange for that date
+ */
 - (JTCalendarDateRange)dateStatusInRange:(NSDate *)date;
 - (BOOL)calendarIsUsingRangeOfDates;
 @end

--- a/JTCalendar/JTCalendar.h
+++ b/JTCalendar/JTCalendar.h
@@ -21,9 +21,13 @@
 @property (weak, nonatomic) JTCalendarContentView *contentView;
 
 @property (weak, nonatomic) id<JTCalendarDataSource> dataSource;
+@property (weak, nonatomic) id<JTCalendarDateRangeDelegate> dateRangeDelegate;
 
 @property (strong, nonatomic) NSDate *currentDate;
 @property (strong, nonatomic) NSDate *currentDateSelected;
+
+@property (strong, nonatomic) NSDate *startDateInRange;
+@property (strong, nonatomic) NSDate *endDateInRange;
 
 @property (strong, nonatomic, readonly) JTCalendarDataCache *dataCache;
 @property (strong, nonatomic, readonly) JTCalendarAppearance *calendarAppearance;
@@ -39,4 +43,6 @@
 
 - (void)repositionViews;
 
+- (JTCalendarDateRange)dateBelongsToSelectedRange:(NSDate *)date;
+- (BOOL)calendarIsUsingRangeOfDates;
 @end

--- a/JTCalendar/JTCalendar.m
+++ b/JTCalendar/JTCalendar.m
@@ -109,6 +109,40 @@
     [self.contentView reloadData];
 }
 
+- (void)setStartDateInRange:(NSDate *)startDateInRange {
+    self->_startDateInRange = startDateInRange;
+    [self reloadAppearance];
+}
+
+- (void)setEndDateInRange:(NSDate *)endDateInRange {
+    if (endDateInRange == nil || [endDateInRange compare:self.startDateInRange] == NSOrderedDescending) {
+        self->_endDateInRange = endDateInRange;
+        [self reloadAppearance];
+    }
+}
+
+- (JTCalendarDateRange)dateBelongsToSelectedRange:(NSDate *)date {
+    if ([self calendarIsUsingRangeOfDates] && self.startDateInRange) {
+        return [self date:date isBetweenDate:self.startDateInRange andDate:self.endDateInRange];
+    } else {
+        return JTCalendarDateNoRangeSelected;
+    }
+}
+
+- (JTCalendarDateRange)date:(NSDate*)date isBetweenDate:(NSDate*)beginDate andDate:(NSDate*)endDate
+{
+    if ([date isEqual:beginDate]) return JTCalendarDateRangeBeginDate;
+    if ([date isEqual:endDate]) return JTCalendarDateRangeEndDate;
+    if (!endDate) endDate = beginDate;
+    if ([date compare:beginDate] == NSOrderedAscending) return JTCalendarDateBeforeRange;
+    if ([date compare:endDate] == NSOrderedDescending) return JTCalendarDateAfterRange;
+    return JTCalendarDateRangeMiddleDate;
+}
+
+- (BOOL)calendarIsUsingRangeOfDates {
+    return self.dateRangeDelegate;
+}
+
 #pragma mark - UIScrollView delegate
 
 - (void)scrollViewDidScroll:(UIScrollView *)sender

--- a/JTCalendar/JTCalendar.m
+++ b/JTCalendar/JTCalendar.m
@@ -121,7 +121,7 @@
     }
 }
 
-- (JTCalendarDateRange)dateBelongsToSelectedRange:(NSDate *)date {
+- (JTCalendarDateRange)dateStatusInRange:(NSDate *)date {
     if ([self calendarIsUsingRangeOfDates] && self.startDateInRange) {
         return [self date:date isBetweenDate:self.startDateInRange andDate:self.endDateInRange];
     } else {

--- a/JTCalendar/JTCalendar.m
+++ b/JTCalendar/JTCalendar.m
@@ -140,7 +140,7 @@
 }
 
 - (BOOL)calendarIsUsingRangeOfDates {
-    return self.dateRangeDelegate;
+    return (BOOL)self.dateRangeDelegate;
 }
 
 #pragma mark - UIScrollView delegate

--- a/JTCalendar/JTCalendar.m
+++ b/JTCalendar/JTCalendar.m
@@ -122,8 +122,9 @@
 }
 
 - (JTCalendarDateRange)dateStatusInRange:(NSDate *)date {
-    if ([self calendarIsUsingRangeOfDates] && self.startDateInRange) {
-        return [self date:date isBetweenDate:self.startDateInRange andDate:self.endDateInRange];
+    if ([self calendarIsUsingRangeOfDates]) {
+        NSDate *from = self.startDateInRange ? self.startDateInRange : [NSDate date];
+        return [self date:date isBetweenDate:from andDate:self.endDateInRange];
     } else {
         return JTCalendarDateNoRangeSelected;
     }

--- a/JTCalendar/JTCalendarAppearance.h
+++ b/JTCalendar/JTCalendarAppearance.h
@@ -64,7 +64,7 @@ typedef NSString *(^JTCalendarMonthBlock)(NSDate *date, JTCalendar *jt_calendar)
 // Day Background and Border
 @property (strong, nonatomic) UIColor *dayBackgroundColor;
 @property (assign, nonatomic) CGFloat dayBorderWidth;
-@property (assign, nonatomic) UIColor *dayBorderColor;
+@property (strong, nonatomic) UIColor *dayBorderColor;
 
 @property (assign, nonatomic) CGFloat dayCircleRatio;
 @property (assign, nonatomic) CGFloat dayDotRatio;

--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -321,8 +321,10 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
     textLabel.textAlignment = NSTextAlignmentCenter;
     textLabel.font = self.calendarManager.calendarAppearance.dayTextFont;
     backgroundView.backgroundColor = self.calendarManager.calendarAppearance.dayBackgroundColor;
-    backgroundView.layer.borderWidth = self.calendarManager.calendarAppearance.dayBorderWidth;
-    backgroundView.layer.borderColor = self.calendarManager.calendarAppearance.dayBorderColor.CGColor;
+    
+    self.layer.borderWidth = self.calendarManager.calendarAppearance.dayBorderWidth;
+    self.layer.borderColor = self.calendarManager.calendarAppearance.dayBorderColor.CGColor;
+    
     [self styleBackgroundForDateRangeIfNeeded];
 
     [self configureConstraintsForSubviews];
@@ -330,7 +332,32 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
 }
 
 - (void)styleBackgroundForDateRangeIfNeeded {
-    JTCalendarDateRange dateRange = [self.calendarManager dateStatusInRange:self.date];
-    [self.calendarManager.dateRangeDelegate styleDayBackgroundView:backgroundView forDate:self.date inRange:dateRange];
+    if (self.calendarManager.calendarIsUsingRangeOfDates) {
+        if (circleView) {
+            [circleView removeFromSuperview];
+            circleView = nil;
+        }
+        if (dotView) {
+            [dotView removeFromSuperview];
+            dotView = nil;
+        }
+        
+        JTCalendarDateRange dateRange = [self.calendarManager dateStatusInRange:self.date];
+        switch (dateRange) {
+            case JTCalendarDateRangeBeginDate:
+                [self setSelected:YES animated:NO];
+                break;
+            case JTCalendarDateRangeEndDate:
+                [self setSelected:YES animated:NO];
+                break;
+            case JTCalendarDateRangeMiddleDate:
+                [self setSelected:YES animated:NO];
+                break;
+            default:
+                [self setSelected:NO animated:NO];
+                break;
+        }
+        [self.calendarManager.dateRangeDelegate styleDayBackgroundView:backgroundView withTextLabel:textLabel forDate:self.date inRange:dateRange];
+    }
 }
 @end

--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -161,10 +161,10 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
     currentMonthIndex = currentMonthIndex % 12;
     
     if(currentMonthIndex == (calendarMonthIndex + 1) % 12){
-        [self.calendarManager loadNextMonth];
+        [self.calendarManager loadNextPage];
     }
     else if(currentMonthIndex == (calendarMonthIndex + 12 - 1) % 12){
-        [self.calendarManager loadPreviousMonth];
+        [self.calendarManager loadPreviousPage];
     }
 }
 

--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -324,7 +324,7 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
 }
 
 - (void)styleBackgroundForDateRangeIfNeeded {
-    JTCalendarDateRange dateRange = [self.calendarManager dateBelongsToSelectedRange:self.date];
-    [self.calendarManager.dateRangeDelegate styleDayBackgroundView:backgroundView forDateInRange:dateRange];
+    JTCalendarDateRange dateRange = [self.calendarManager dateStatusInRange:self.date];
+    [self.calendarManager.dateRangeDelegate styleDayBackgroundView:backgroundView forDate:self.date inRange:dateRange];
 }
 @end

--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -160,10 +160,10 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
         
     currentMonthIndex = currentMonthIndex % 12;
     
-    if(currentMonthIndex == (calendarMonthIndex + 1) % 12){
+    if(![self.calendarManager calendarIsUsingRangeOfDates] && currentMonthIndex == (calendarMonthIndex + 1) % 12){
         [self.calendarManager loadNextPage];
     }
-    else if(currentMonthIndex == (calendarMonthIndex + 12 - 1) % 12){
+    else if(![self.calendarManager calendarIsUsingRangeOfDates] && currentMonthIndex == (calendarMonthIndex + 12 - 1) % 12){
         [self.calendarManager loadPreviousPage];
     }
 }
@@ -258,6 +258,7 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
     
     BOOL selected = [self isSameDate:[self.calendarManager currentDateSelected]];
     [self setSelected:selected animated:NO];
+    [self styleBackgroundForDateRangeIfNeeded];
 }
 
 - (BOOL)isToday
@@ -316,9 +317,14 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
     backgroundView.backgroundColor = self.calendarManager.calendarAppearance.dayBackgroundColor;
     backgroundView.layer.borderWidth = self.calendarManager.calendarAppearance.dayBorderWidth;
     backgroundView.layer.borderColor = self.calendarManager.calendarAppearance.dayBorderColor.CGColor;
-    
+    [self styleBackgroundForDateRangeIfNeeded];
+
     [self configureConstraintsForSubviews];
     [self setSelected:isSelected animated:NO];
 }
 
+- (void)styleBackgroundForDateRangeIfNeeded {
+    JTCalendarDateRange dateRange = [self.calendarManager dateBelongsToSelectedRange:self.date];
+    [self.calendarManager.dateRangeDelegate styleDayBackgroundView:backgroundView forDateInRange:dateRange];
+}
 @end

--- a/JTCalendar/JTCalendarMonthView.m
+++ b/JTCalendar/JTCalendarMonthView.m
@@ -89,7 +89,7 @@
     
     CGFloat y = 0;
     CGFloat width = self.frame.size.width;
-    CGFloat height = self.frame.size.height / weeksToDisplay;
+    CGFloat height = roundf(self.frame.size.height / weeksToDisplay);
     
     for(int i = 0; i < self.subviews.count; ++i){
         UIView *view = self.subviews[i];

--- a/JTCalendar/JTCalendarViewDataSource.h
+++ b/JTCalendar/JTCalendarViewDataSource.h
@@ -35,5 +35,5 @@ typedef enum : NSUInteger {
 
 @protocol JTCalendarDateRangeDelegate <NSObject>
 @required
-- (void)styleDayBackgroundView:(UIView *)backgroundView forDate:(NSDate *)date inRange:(JTCalendarDateRange)dateRange;
+- (void)styleDayBackgroundView:(UIView *)backgroundView withTextLabel:(UILabel *)text forDate:(NSDate *)date inRange:(JTCalendarDateRange)dateRange;
 @end

--- a/JTCalendar/JTCalendarViewDataSource.h
+++ b/JTCalendar/JTCalendarViewDataSource.h
@@ -32,5 +32,5 @@ typedef enum : NSUInteger {
 
 @protocol JTCalendarDateRangeDelegate <NSObject>
 @required
-- (void)styleDayBackgroundView:(UIView *)backgroundView forDateInRange:(JTCalendarDateRange)dateRange;
+- (void)styleDayBackgroundView:(UIView *)backgroundView forDate:(NSDate *)date inRange:(JTCalendarDateRange)dateRange;
 @end

--- a/JTCalendar/JTCalendarViewDataSource.h
+++ b/JTCalendar/JTCalendarViewDataSource.h
@@ -19,3 +19,18 @@
 - (void)calendarDidLoadNextPage;
 
 @end
+
+//Range of dates
+typedef enum : NSUInteger {
+    JTCalendarDateNoRangeSelected, //the type used when there isn't a date range specified at all
+    JTCalendarDateBeforeRange,
+    JTCalendarDateAfterRange,
+    JTCalendarDateRangeBeginDate,
+    JTCalendarDateRangeEndDate,
+    JTCalendarDateRangeMiddleDate
+} JTCalendarDateRange;
+
+@protocol JTCalendarDateRangeDelegate <NSObject>
+@required
+- (void)styleDayBackgroundView:(UIView *)backgroundView forDateInRange:(JTCalendarDateRange)dateRange;
+@end


### PR DESCRIPTION
Hey @jonathantribouharet, thanks for sharing this calendar, its amazing and very customizable. 

I have a need for my current project where I need to be able to pick a range of dates, coloring the dates in the range differently than the ones before and after, etc. I've modified the calendar to support that, giving the user the opportunity to change the backgroundView however it needs when picking up the dates. 

The logic I added doesn't break, conflict or anything like that with the previous logic. It just adds functionality. I've verified and works well in both, expanded and collapsed calendars. 

Please check the ViewController of your the Example project to see how it works. The user just needs to set a new delegate and respond the method that is required to style the dates accordingly. 

Here you have a video showing how it works with the Sample project you already provide in github:
http://quick.as/kgyCm1L
 
And a screenshot: 
![image](https://cloud.githubusercontent.com/assets/1252619/6599928/c8e491e2-c80c-11e4-8af5-6de78c85a204.png)

I thought it could be useful for others. Let me know what you think, and again, thanks for sharing your code.