### PR TITLE
Little adjustment in the position of dot view

### DIFF
--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -121,7 +121,7 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
     circleView.layer.cornerRadius = sizeCircle / 2.;
     
     dotView.frame = CGRectMake(0, 0, sizeDot, sizeDot);
-    dotView.center = CGPointMake(self.frame.size.width / 2., (self.frame.size.height / 2.) + sizeDot * 2.5);
+    dotView.center = CGPointMake(self.frame.size.width / 2., (self.frame.size.height / 2.) + sizeCircle / 2 - sizeDot);
     dotView.layer.cornerRadius = sizeDot / 2.;
 }
 

--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -121,7 +121,7 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
     circleView.layer.cornerRadius = sizeCircle / 2.;
     
     dotView.frame = CGRectMake(0, 0, sizeDot, sizeDot);
-    dotView.center = CGPointMake(self.frame.size.width / 2., (self.frame.size.height / 2.) + sizeCircle / 2 - sizeDot);
+    dotView.center = CGPointMake(self.frame.size.width / 2., (self.frame.size.height / 2.) + sizeCircle / 2 - sizeDot / 2);
     dotView.layer.cornerRadius = sizeDot / 2.;
 }
 


### PR DESCRIPTION
Hi Jonathan, I have made a little change and reopened this pull request.

In this case I have attached two pictures to see the difference between the different solutions.

```_calendar.calendarAppearance.dayDotRatio = 0.3f;```

In the first image the position is calculated relative to the circle: ```sizeCircle / 2 - sizeDot / 2```
![captura de pantalla 2015-03-23 a las 10 21 28](https://cloud.githubusercontent.com/assets/4289570/6777477/5c46ab0a-d14a-11e4-9a9b-84edd463c4b4.png)

The second is an absolute position calculated by multiplying the size of 2.5: ```sizeDot * 2.5```
![captura de pantalla 2015-03-23 a las 10 22 16](https://cloud.githubusercontent.com/assets/4289570/6777479/5f849764-d14a-11e4-8cc2-9f426ca85890.png)

