### PR TITLE
Add locale field to JTCalendarAppearance

### DIFF
--- a/Example/Example/ViewController.m
+++ b/Example/Example/ViewController.m
@@ -40,8 +40,8 @@
             if(!dateFormatter){
                 dateFormatter = [NSDateFormatter new];
                 dateFormatter.timeZone = jt_calendar.calendarAppearance.calendar.timeZone;
-                dateFormatter.locale = jt_calendar.calendarAppearance.locale;
             }
+            dateFormatter.locale = jt_calendar.calendarAppearance.locale;
             
             while(currentMonthIndex <= 0){
                 currentMonthIndex += 12;

--- a/Example/Example/ViewController.m
+++ b/Example/Example/ViewController.m
@@ -28,6 +28,7 @@
         self.calendar.calendarAppearance.dayCircleRatio = 9. / 10.;
         self.calendar.calendarAppearance.ratioContentMenu = 2.;
         self.calendar.calendarAppearance.focusSelectedDayChangeMode = YES;
+        self.calendar.calendarAppearance.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"uk_UA"];
         
         // Customize the text for each month
         self.calendar.calendarAppearance.monthBlock = ^NSString *(NSDate *date, JTCalendar *jt_calendar){
@@ -39,6 +40,7 @@
             if(!dateFormatter){
                 dateFormatter = [NSDateFormatter new];
                 dateFormatter.timeZone = jt_calendar.calendarAppearance.calendar.timeZone;
+                dateFormatter.locale = jt_calendar.calendarAppearance.locale;
             }
             
             while(currentMonthIndex <= 0){

--- a/JTCalendar/JTCalendar.m
+++ b/JTCalendar/JTCalendar.m
@@ -12,6 +12,7 @@
 @interface JTCalendar(){
     BOOL cacheLastWeekMode;
     NSUInteger cacheFirstWeekDay;
+    NSString *cacheLocaleIdentifier;
 }
 
 @end
@@ -51,6 +52,7 @@
     
     cacheLastWeekMode = self.calendarAppearance.isWeekMode;
     cacheFirstWeekDay = self.calendarAppearance.calendar.firstWeekday;
+    cacheLocaleIdentifier = self.calendarAppearance.locale.localeIdentifier;
     
     [self.menuMonthsView setCurrentDate:self.currentDate];
     [self.menuMonthsView reloadAppearance];
@@ -83,9 +85,13 @@
     [self.menuMonthsView reloadAppearance];
     [self.contentView reloadAppearance];
     
-    if(cacheLastWeekMode != self.calendarAppearance.isWeekMode || cacheFirstWeekDay != self.calendarAppearance.calendar.firstWeekday){
+    if (cacheLastWeekMode != self.calendarAppearance.isWeekMode ||
+        cacheFirstWeekDay != self.calendarAppearance.calendar.firstWeekday ||
+        ![cacheLocaleIdentifier isEqualToString:self.calendarAppearance.locale.localeIdentifier])
+    {
         cacheLastWeekMode = self.calendarAppearance.isWeekMode;
         cacheFirstWeekDay = self.calendarAppearance.calendar.firstWeekday;
+        cacheLocaleIdentifier = self.calendarAppearance.locale.localeIdentifier;
         
         if(self.calendarAppearance.focusSelectedDayChangeMode && self.currentDateSelected){
             [self setCurrentDate:self.currentDateSelected];

--- a/JTCalendar/JTCalendarAppearance.h
+++ b/JTCalendar/JTCalendarAppearance.h
@@ -60,6 +60,7 @@ typedef NSString *(^JTCalendarMonthBlock)(NSDate *date, JTCalendar *jt_calendar)
 @property (nonatomic) UIFont *dayTextFont;
 
 @property (nonatomic) NSString *dayFormat;
+@property (nonatomic) NSLocale *locale;
 
 // Day Background and Border
 @property (nonatomic) UIColor *dayBackgroundColor;

--- a/JTCalendar/JTCalendarAppearance.m
+++ b/JTCalendar/JTCalendarAppearance.m
@@ -81,6 +81,7 @@
         if(!dateFormatter){
             dateFormatter = [NSDateFormatter new];
             dateFormatter.timeZone = jt_calendar.calendarAppearance.calendar.timeZone;
+            dateFormatter.locale = jt_calendar.calendarAppearance.locale;
         }
         
         while(currentMonthIndex <= 0){

--- a/JTCalendar/JTCalendarAppearance.m
+++ b/JTCalendar/JTCalendarAppearance.m
@@ -81,8 +81,8 @@
         if(!dateFormatter){
             dateFormatter = [NSDateFormatter new];
             dateFormatter.timeZone = jt_calendar.calendarAppearance.calendar.timeZone;
-            dateFormatter.locale = jt_calendar.calendarAppearance.locale;
         }
+        dateFormatter.locale = jt_calendar.calendarAppearance.locale;
         
         while(currentMonthIndex <= 0){
             currentMonthIndex += 12;

--- a/JTCalendar/JTCalendarDataCache.m
+++ b/JTCalendar/JTCalendarDataCache.m
@@ -27,6 +27,7 @@
     
     dateFormatter = [NSDateFormatter new];
     [dateFormatter setDateFormat:@"yyyy-MM-dd"];
+    dateFormatter.locale = self.calendarManager.calendarAppearance.locale;
     events = [NSMutableDictionary new];
     
     return self;

--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -132,6 +132,7 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
         dateFormatter = [NSDateFormatter new];
         dateFormatter.timeZone = self.calendarManager.calendarAppearance.calendar.timeZone;
         [dateFormatter setDateFormat:self.calendarManager.calendarAppearance.dayFormat];
+        dateFormatter.locale = self.calendarManager.calendarAppearance.locale;
     }
     
     self->_date = date;
@@ -293,6 +294,7 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
         dateFormatter = [NSDateFormatter new];
         dateFormatter.timeZone = self.calendarManager.calendarAppearance.calendar.timeZone;
         [dateFormatter setDateFormat:@"dd-MM-yyyy"];
+        dateFormatter.locale = self.calendarManager.calendarAppearance.locale;
     }
     
     if(!cacheCurrentDateText){

--- a/JTCalendar/JTCalendarMonthWeekDaysView.m
+++ b/JTCalendar/JTCalendarMonthWeekDaysView.m
@@ -57,6 +57,7 @@ static NSArray *cacheDaysOfWeeks;
     }
     
     NSDateFormatter *dateFormatter = [NSDateFormatter new];
+    dateFormatter.locale = self.calendarManager.calendarAppearance.locale;
     NSMutableArray *days = nil;
     
     switch(self.calendarManager.calendarAppearance.weekDayFormat) {


### PR DESCRIPTION
Hello,
Thanks for your great component, it's really handy! I use it in the project I'm currently working on and I've had a need to set up calendar locale in run-time manually with `MCLocalization`. For this, I have forked your repo and added a `NSLocale *locale` field to `JTCalendarAppearance` class. You might want to review changes and merge it if you think it could be of any use.