### PR TITLE
Added ability to set a custom day circle color

### DIFF
--- a/JTCalendar/JTCalendarAppearance.h
+++ b/JTCalendar/JTCalendarAppearance.h
@@ -20,6 +20,16 @@ typedef NS_ENUM(NSInteger, JTCalendarWeekDayFormat) {
 typedef NSString *(^JTCalendarMonthBlock)(NSDate *date, JTCalendar *jt_calendar);
 
 /**
+ *	A function that should return a background color to set for the given date.
+ *
+ *	@param date        The date for which to set the background color.
+ *	@param jt_calendar The calendar that contains the date.
+ *
+ *	@return The color to set as a background.
+ */
+typedef UIColor *(^JTCalendarDayCircleColorBlock)(NSDate *date, JTCalendar *jt_calendar);
+
+/**
  *	A Boolean value indicating whether the calendar should show a month or a week.
  *
  *	The default value of this property is @c NO.
@@ -62,6 +72,20 @@ typedef NSString *(^JTCalendarMonthBlock)(NSDate *date, JTCalendar *jt_calendar)
  */
 @property (assign, nonatomic) BOOL autoChangeMonth;
 @property (copy, nonatomic) JTCalendarMonthBlock monthBlock;
+
+/**
+ *	A function that is called for every day and should return the color to set as background.
+ *
+ *	The default value that it returns is @c clearColor.
+ */
+@property (copy, nonatomic) JTCalendarDayCircleColorBlock dayCircleColorBlock;
+
+/**
+ *	A function that is called for every day from the other months and should return the color to set as background.
+ *
+ *	The default value that it returns is @c clearColor.
+ */
+@property (copy, nonatomic) JTCalendarDayCircleColorBlock dayCircleColorOtherMonthBlock;
 
 #pragma mark - Weekday
 

--- a/JTCalendar/JTCalendarAppearance.h
+++ b/JTCalendar/JTCalendarAppearance.h
@@ -74,6 +74,26 @@ typedef UIColor *(^JTCalendarDayCircleColorBlock)(NSDate *date, JTCalendar *jt_c
 @property (copy, nonatomic) JTCalendarMonthBlock monthBlock;
 
 /**
+ *	A Boolean value indicating whether to use the circle's color set with
+ *	@c dayCircleColorBlock or @c dayCircleColorOtherMonthBlock for the currently selected day.
+ *
+ *	@remarks If set to @c YES, the @c dayCircleColorSelected is ignored.
+ *
+ *	The default value of this property is @c NO.
+ */
+@property (assign, nonatomic) BOOL useDayCircleColorForSelected;
+
+/**
+ *	A Boolean value indicating whether to use the circle's color custom color setter blocks.
+ *
+ *	@see dayCircleColorBlock
+ *	@see dayCircleColorOtherMonthBlock
+ *
+ *	The default value of this property is @c NO.
+ */
+@property (assign, nonatomic) BOOL useCustomDayCircleColor;
+
+/**
  *	A function that is called for every day and should return the color to set as background.
  *
  *	The default value that it returns is @c clearColor.

--- a/JTCalendar/JTCalendarAppearance.m
+++ b/JTCalendar/JTCalendarAppearance.m
@@ -90,6 +90,9 @@
         return [[dateFormatter standaloneMonthSymbols][currentMonthIndex - 1] capitalizedString];
     };
 
+	self.useDayCircleColorForSelected = NO;
+	self.useCustomDayCircleColor = NO;
+
     self.dayCircleColorBlock = self.dayCircleColorOtherMonthBlock = ^UIColor *(NSDate *date, JTCalendar *jt_calendar){
         return [UIColor clearColor];
     };

--- a/JTCalendar/JTCalendarAppearance.m
+++ b/JTCalendar/JTCalendarAppearance.m
@@ -89,6 +89,10 @@
         
         return [[dateFormatter standaloneMonthSymbols][currentMonthIndex - 1] capitalizedString];
     };
+
+    self.dayCircleColorBlock = self.dayCircleColorOtherMonthBlock = ^UIColor *(NSDate *date, JTCalendar *jt_calendar){
+        return [UIColor clearColor];
+    };
 }
 
 - (NSCalendar *)calendar

--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -199,17 +199,18 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
     circleView.transform = CGAffineTransformIdentity;
     CGAffineTransform tr = CGAffineTransformIdentity;
     CGFloat opacity = 1.;
+	JTCalendarAppearance *calendarAppearance = self.calendarManager.calendarAppearance;
     
     if(selected){
         if(!self.isOtherMonth){
-            circleView.color = [self.calendarManager.calendarAppearance dayCircleColorSelected];
-            textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorSelected];
-            dotView.color = [self.calendarManager.calendarAppearance dayDotColorSelected];
+            circleView.color = [calendarAppearance dayCircleColorSelected];
+            textLabel.textColor = [calendarAppearance dayTextColorSelected];
+            dotView.color = [calendarAppearance dayDotColorSelected];
         }
         else{
-            circleView.color = [self.calendarManager.calendarAppearance dayCircleColorSelectedOtherMonth];
-            textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorSelectedOtherMonth];
-            dotView.color = [self.calendarManager.calendarAppearance dayDotColorSelectedOtherMonth];
+            circleView.color = [calendarAppearance dayCircleColorSelectedOtherMonth];
+            textLabel.textColor = [calendarAppearance dayTextColorSelectedOtherMonth];
+            dotView.color = [calendarAppearance dayDotColorSelectedOtherMonth];
         }
         
         circleView.transform = CGAffineTransformScale(CGAffineTransformIdentity, 0.1, 0.1);
@@ -217,27 +218,39 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
     }
     else if([self isToday]){
         if(!self.isOtherMonth){
-            circleView.color = [self.calendarManager.calendarAppearance dayCircleColorToday];
-            textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorToday];
-            dotView.color = [self.calendarManager.calendarAppearance dayDotColorToday];
+            circleView.color = [calendarAppearance dayCircleColorToday];
+            textLabel.textColor = [calendarAppearance dayTextColorToday];
+            dotView.color = [calendarAppearance dayDotColorToday];
         }
         else{
-            circleView.color = [self.calendarManager.calendarAppearance dayCircleColorTodayOtherMonth];
-            textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorTodayOtherMonth];
-            dotView.color = [self.calendarManager.calendarAppearance dayDotColorTodayOtherMonth];
+            circleView.color = [calendarAppearance dayCircleColorTodayOtherMonth];
+            textLabel.textColor = [calendarAppearance dayTextColorTodayOtherMonth];
+            dotView.color = [calendarAppearance dayDotColorTodayOtherMonth];
         }
     }
     else{
         if(!self.isOtherMonth){
-            textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColor];
-            dotView.color = [self.calendarManager.calendarAppearance dayDotColor];
+            textLabel.textColor = [calendarAppearance dayTextColor];
+            dotView.color = [calendarAppearance dayDotColor];
         }
         else{
-            textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorOtherMonth];
-            dotView.color = [self.calendarManager.calendarAppearance dayDotColorOtherMonth];
+            textLabel.textColor = [calendarAppearance dayTextColorOtherMonth];
+            dotView.color = [calendarAppearance dayDotColorOtherMonth];
         }
-        
-        opacity = 0.;
+
+        if(self.date && calendarAppearance){
+            if(self.isOtherMonth){
+                circleView.color = calendarAppearance.dayCircleColorOtherMonthBlock(self.date, self.calendarManager);
+            }
+            else{
+                circleView.color = calendarAppearance.dayCircleColorBlock(self.date, self.calendarManager);
+            }
+
+            opacity = 1;
+        }
+        else{
+            opacity = 0.;
+        }
     }
     
     if(animated){

--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -203,12 +203,18 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
     
     if(selected){
         if(!self.isOtherMonth){
-            circleView.color = [calendarAppearance dayCircleColorSelected];
+            if(!calendarAppearance.useDayCircleColorForSelected){
+                circleView.color = [calendarAppearance dayCircleColorSelected];
+            }
+
             textLabel.textColor = [calendarAppearance dayTextColorSelected];
             dotView.color = [calendarAppearance dayDotColorSelected];
         }
         else{
-            circleView.color = [calendarAppearance dayCircleColorSelectedOtherMonth];
+            if(!calendarAppearance.useDayCircleColorForSelected){
+                circleView.color = [calendarAppearance dayCircleColorSelectedOtherMonth];
+            }
+
             textLabel.textColor = [calendarAppearance dayTextColorSelectedOtherMonth];
             dotView.color = [calendarAppearance dayDotColorSelectedOtherMonth];
         }
@@ -238,7 +244,7 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
             dotView.color = [calendarAppearance dayDotColorOtherMonth];
         }
 
-        if(self.date && calendarAppearance){
+        if(self.date && calendarAppearance && calendarAppearance.useCustomDayCircleColor){
             if(self.isOtherMonth){
                 circleView.color = calendarAppearance.dayCircleColorOtherMonthBlock(self.date, self.calendarManager);
             }

--- a/JTCalendar/JTCircleView.m
+++ b/JTCalendar/JTCircleView.m
@@ -19,7 +19,7 @@
     }
     
     self.backgroundColor = [UIColor clearColor];
-    self.color = [UIColor whiteColor];
+    self.color = [UIColor clearColor];
     
     return self;
 }


### PR DESCRIPTION
Added block properties that are called for every drawn day and should return the color to set for the circle background.

I also maintained the current behavior so no superfluous calls are made.

Here is an example of using this feature:

	JTCalendarAppearance *calendarAppearance = self.calendar.calendarAppearance;

	calendarAppearance.useCustomDayCircleColor = YES;

	UIColor *greenColor = [UIColor colorWithRed:0.298 green:0.855 blue:0.392 alpha:1];
	UIColor *redColor = [UIColor colorWithRed:0.757 green:0.318 blue:0.157 alpha:1];

	calendarAppearance.dayCircleColorBlock = ^UIColor *(NSDate *date, JTCalendar *jt_calendar) {
		BOOL isStuffComplete = [myController isStuffCompletedForDate:date];

		return isStuffComplete ? greenColor : redColor;
	};

Which shows up like this:

![ios simulator screen shot 3 apr 2015 14 35 04](https://cloud.githubusercontent.com/assets/5748627/6981695/d8466b7e-da0e-11e4-8738-2417b0f9f354.jpg)

And if I also use:

	calendarAppearance.useDayCircleColorForSelected = YES;

it shows up like this:

![ios simulator screen shot 3 apr 2015 14 35 26](https://cloud.githubusercontent.com/assets/5748627/6981700/ed29a704-da0e-11e4-9101-69c394298595.jpg)

where the 2nd is selected _(and also "completed")_.

I think this will be useful for easy creating activity history logs.

Here is a month view screenshot:

![ios simulator screen shot 3 apr 2015 10 58 19](https://cloud.githubusercontent.com/assets/5748627/6981704/f842260c-da0e-11e4-9676-4a4b5084da54.jpg)


