### PR TITLE
fixed beginning of week inset when in weekOnlyMode

### DIFF
--- a/JTCalendar/JTCalendarContentView.m
+++ b/JTCalendar/JTCalendarContentView.m
@@ -114,8 +114,7 @@
         else{
             dayComponent.day = 7 * (i - (NUMBER_PAGES_LOADED / 2));
             
-            NSDate *monthDate = [calendar dateByAddingComponents:dayComponent toDate:self.currentDate options:0];
-            monthDate = [self beginningOfWeek:monthDate];
+            NSDate *monthDate = [self beginningOfWeek:currentDate];
             [monthView setBeginningOfMonth:monthDate];
         }
     }


### PR DESCRIPTION
When in weekOnlyMode, the logic incorrectly sets the beginning visible week to the beginning of the month. But when you're in weekOnlyMode, you only care about the start of the week of the set currentDate.