### PR TITLE
Add appearance for today's circle color and timezone fix

### DIFF
--- a/JTCalendar/JTCalendarAppearance.h
+++ b/JTCalendar/JTCalendarAppearance.h
@@ -98,6 +98,12 @@ typedef NSString *(^JTCalendarMonthBlock)(NSDate *date, JTCalendar *jt_calendar)
  *	The default value of this property is this blue nuance:
  *	@code [UIColor colorWithRed:0x33/256. green:0xB3/256. blue:0xEC/256. alpha:.5] @endcode
  */
+@property (nonatomic) UIColor *dayCircleColorTodaySelected;
+
+/**
+ *	The default value of this property is this blue nuance:
+ *	@code [UIColor colorWithRed:0x33/256. green:0xB3/256. blue:0xEC/256. alpha:.5] @endcode
+ */
 @property (nonatomic) UIColor *dayCircleColorToday;
 
 /**

--- a/JTCalendar/JTCalendarAppearance.m
+++ b/JTCalendar/JTCalendarAppearance.m
@@ -82,9 +82,9 @@
         static NSDateFormatter *dateFormatter;
         if(!dateFormatter){
             dateFormatter = [NSDateFormatter new];
-            dateFormatter.timeZone = jt_calendar.calendarAppearance.calendar.timeZone;
         }
-        
+        dateFormatter.timeZone = jt_calendar.calendarAppearance.calendar.timeZone;
+
         while(currentMonthIndex <= 0){
             currentMonthIndex += 12;
         }

--- a/JTCalendar/JTCalendarAppearance.m
+++ b/JTCalendar/JTCalendarAppearance.m
@@ -59,12 +59,14 @@
     self.dayCircleColorSelected = [UIColor redColor];
     self.dayTextColorSelected = [UIColor whiteColor];
     self.dayDotColorSelected = [UIColor whiteColor];
-    
+
     self.dayCircleColorSelectedOtherMonth = self.dayCircleColorSelected;
     self.dayTextColorSelectedOtherMonth = self.dayTextColorSelected;
     self.dayDotColorSelectedOtherMonth = self.dayDotColorSelected;
     
     self.dayCircleColorToday = [UIColor colorWithRed:0x33/256. green:0xB3/256. blue:0xEC/256. alpha:.5];
+    self.dayCircleColorTodaySelected = self.dayCircleColorToday;
+
     self.dayTextColorToday = [UIColor whiteColor];
     self.dayDotColorToday = [UIColor whiteColor];
     

--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -130,10 +130,10 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
     static NSDateFormatter *dateFormatter;
     if(!dateFormatter){
         dateFormatter = [NSDateFormatter new];
-        dateFormatter.timeZone = self.calendarManager.calendarAppearance.calendar.timeZone;
         [dateFormatter setDateFormat:self.calendarManager.calendarAppearance.dayFormat];
     }
-    
+    dateFormatter.timeZone = self.calendarManager.calendarAppearance.calendar.timeZone;
+
     self->_date = date;
     
     textLabel.text = [dateFormatter stringFromDate:date];
@@ -295,10 +295,10 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
     static NSDateFormatter *dateFormatter;
     if(!dateFormatter){
         dateFormatter = [NSDateFormatter new];
-        dateFormatter.timeZone = self.calendarManager.calendarAppearance.calendar.timeZone;
         [dateFormatter setDateFormat:@"dd-MM-yyyy"];
     }
-    
+    dateFormatter.timeZone = self.calendarManager.calendarAppearance.calendar.timeZone;
+
     if(!cacheCurrentDateText){
         cacheCurrentDateText = [dateFormatter stringFromDate:self.date];
     }

--- a/JTCalendar/JTCalendarDayView.m
+++ b/JTCalendar/JTCalendarDayView.m
@@ -201,15 +201,19 @@ static NSString *const kJTCalendarDaySelected = @"kJTCalendarDaySelected";
     CGFloat opacity = 1.;
     
     if(selected){
-        if(!self.isOtherMonth){
-            circleView.color = [self.calendarManager.calendarAppearance dayCircleColorSelected];
-            textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorSelected];
-            dotView.color = [self.calendarManager.calendarAppearance dayDotColorSelected];
-        }
-        else{
+        if(self.isOtherMonth){
             circleView.color = [self.calendarManager.calendarAppearance dayCircleColorSelectedOtherMonth];
             textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorSelectedOtherMonth];
             dotView.color = [self.calendarManager.calendarAppearance dayDotColorSelectedOtherMonth];
+        } else if ([self isToday]) {
+            circleView.color = [self.calendarManager.calendarAppearance dayCircleColorTodaySelected];
+            textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorSelected];
+            dotView.color = [self.calendarManager.calendarAppearance dayDotColorSelected];
+        }
+        else {
+            circleView.color = [self.calendarManager.calendarAppearance dayCircleColorSelected];
+            textLabel.textColor = [self.calendarManager.calendarAppearance dayTextColorSelected];
+            dotView.color = [self.calendarManager.calendarAppearance dayDotColorSelected];
         }
         
         circleView.transform = CGAffineTransformScale(CGAffineTransformIdentity, 0.1, 0.1);


### PR DESCRIPTION
To mimic iOS standard calendar color code, this library had to implement a specific property for today's selected circle color.

For example, on iOS calendar, today's selected circle color is red and other days circle color is black.

Also, timezone changes were being ignored since NSDateFormatter timezone setter was inside a static check.