### PR TITLE
Some months showed the last week overlapping with the week day view.

### DIFF
--- a/JTCalendar/Views/JTCalendarPageView.m
+++ b/JTCalendar/Views/JTCalendarPageView.m
@@ -118,6 +118,8 @@
         
         weekView.hidden = YES;
     }
+	
+	[self layoutSubviews];
 }
 
 - (void)layoutSubviews


### PR DESCRIPTION
Week height wasn't being updated even though _numberOfWeeksDisplayed was in reload.

Please check before merging. I'm not sure how you would fix this, and I've only confirmed the fix with JTVerticalCalendarView.