### PR TITLE
Add API for users to check and be notified of scrolling state

### DIFF
--- a/JTCalendar/JTCalendarDelegate.h
+++ b/JTCalendar/JTCalendarDelegate.h
@@ -61,10 +61,20 @@
  */
 - (void)calendarDidLoadPreviousPage:(JTCalendarManager *)calendar;
 
+/**
+ *  Indicates the previous page finished scrolling after becoming the current page.
+ */
+- (void)calendarDidFinishScrollingToPreviousPage:(JTCalendarManager *)calendar;
+
 /*!
  * Indicate the next page became the current page.
  */
 - (void)calendarDidLoadNextPage:(JTCalendarManager *)calendar;
+
+/**
+ *  Indicates the next page finished scrolling after becoming the current page.
+ */
+- (void)calendarDidFinishScrollingToNextPage:(JTCalendarManager *)calendar;
 
 /*!
  * Provide a view conforming to `JTCalendarPage` protocol, used as page for the contentView.

--- a/JTCalendar/Managers/JTCalendarScrollManager.h
+++ b/JTCalendar/Managers/JTCalendarScrollManager.h
@@ -27,5 +27,8 @@
 
 - (void)updateMenuContentOffset:(CGFloat)percentage pageMode:(NSUInteger)pageMode;
 - (void)updateHorizontalContentOffset:(CGFloat)percentage;
+- (void)endDragging;
+- (void)endDecelerating;
+- (void)endHorizontalScrollingAnimation;
 
 @end

--- a/JTCalendar/Managers/JTCalendarScrollManager.m
+++ b/JTCalendar/Managers/JTCalendarScrollManager.m
@@ -39,4 +39,31 @@
     _horizontalContentView.contentOffset = CGPointMake(percentage * _horizontalContentView.contentSize.width, 0);
 }
 
+- (void)endDragging
+{
+    if(![_horizontalContentView.delegate respondsToSelector:@selector(scrollViewDidEndDragging:willDecelerate:)]){
+        return;
+    }
+
+    [_horizontalContentView.delegate scrollViewDidEndDragging:_horizontalContentView willDecelerate:NO];
+}
+
+- (void)endDecelerating
+{
+    if(![_horizontalContentView.delegate respondsToSelector:@selector(scrollViewDidEndDecelerating:)]){
+        return;
+    }
+
+    [_horizontalContentView.delegate scrollViewDidEndDecelerating:_horizontalContentView];
+}
+
+- (void)endHorizontalScrollingAnimation
+{
+    if(![_horizontalContentView.delegate respondsToSelector:@selector(scrollViewDidEndScrollingAnimation:)]){
+        return;
+    }
+
+    [_horizontalContentView.delegate scrollViewDidEndScrollingAnimation:_horizontalContentView];
+}
+
 @end

--- a/JTCalendar/Views/JTCalendarMenuView.h
+++ b/JTCalendar/Views/JTCalendarMenuView.h
@@ -17,6 +17,8 @@
 
 @property (nonatomic, readonly) UIScrollView *scrollView;
 
+@property (nonatomic, assign, readonly) BOOL scrolling;
+
 /*!
  * Must be call if override the class
  */

--- a/JTCalendar/Views/JTCalendarMenuView.m
+++ b/JTCalendar/Views/JTCalendarMenuView.m
@@ -78,6 +78,15 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
     [self resizeViewsIfWidthChanged];
 }
 
+#pragma mark - Properties
+
+- (BOOL)scrolling
+{
+    return self.scrollView.dragging || self.scrollView.decelerating;
+}
+
+#pragma mark - UIScrollViewDelegate
+
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
     if(_scrollView.contentSize.width <= 0){
@@ -86,6 +95,25 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
 
     [_manager.scrollManager updateHorizontalContentOffset:(_scrollView.contentOffset.x / _scrollView.contentSize.width)];
 }
+
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
+{
+    if(!decelerate){
+        [_manager.scrollManager endDragging];
+    }
+}
+
+- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
+{
+    [_manager.scrollManager endDecelerating];
+}
+
+- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
+{
+    [_manager.scrollManager endHorizontalScrollingAnimation];
+}
+
+#pragma mark -
 
 - (void)resizeViewsIfWidthChanged
 {

--- a/JTCalendar/Views/JTHorizontalCalendarView.h
+++ b/JTCalendar/Views/JTHorizontalCalendarView.h
@@ -15,6 +15,8 @@
 
 @property (nonatomic) NSDate *date;
 
+@property (nonatomic, assign, readonly) BOOL scrolling;
+
 /*!
  * Must be call if override the class
  */


### PR DESCRIPTION
Hi! I've had a lot of success with JTCalendar on a recent project and just finished updating it to the 2.x version. I found that it can involve a lot of work to properly update the calendar asyncronously (as encouraged in the README for long-running update tasks) because you have to avoid reloading the calendar manager while either scroll view is still scrolling or else the contentOffset and/or view layouts seem to get messed up. After doing a lot of this work outside of JTCalendar, it seemed like it would be something that would be needed by others so I moved the changes into the library instead.

This change adds `scrolling` properties to the menu and horizontal content views so that users can check the current state before calling `reload` and adds two more delegate methods called when the content scroll view finishes scrolling. This also occurs when the content scrolling is triggered by menu view scrolling. This means that users can update their data cache when `calendarDidLoad*Page` is called and then reload the calendar when the new `calendarDidFinishScrollingTo*Page` is called.

I haven't made any changes to the vertical content view because I wasn't using it in the project this came from, but can either leave it to you or continue with that once you have a chance to look at the work thus far. Thanks!