### PR TITLE
Fixes the issue #207: “months don't always snap to their edge”

### DIFF
--- a/JTCalendar/Views/JTHorizontalCalendarView.m
+++ b/JTCalendar/Views/JTHorizontalCalendarView.m
@@ -139,7 +139,10 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
     }
     
     CGSize size = self.frame.size;
-    CGPoint point = CGPointMake(self.contentOffset.x - size.width, 0);
+    CGFloat x = self.contentOffset.x - size.width;
+    x -= (fmod(x, size.width));
+    CGPoint point = CGPointMake(x, 0);
+    
     [self setContentOffset:point animated:YES];
 }
 
@@ -154,7 +157,10 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
     }
     
     CGSize size = self.frame.size;
-    CGPoint point = CGPointMake(self.contentOffset.x + size.width, 0);
+    CGFloat x = self.contentOffset.x + size.width;
+    x -= (fmod(x, size.width));
+    CGPoint point = CGPointMake(x, 0);
+    
     [self setContentOffset:point animated:YES];
 }
 


### PR DESCRIPTION
Looking at your implementation, this is the best results I could get without touching a lot of stuff. With this fix the months always snap to their edge.

The issue: if you place arrows in your calendar to call loadPreviousPageWithAnimation and loadNextPageWithAnimation, the bug appears when the user taps on an arrow multiple times, without letting the previous animation to finish. 

I pushed two branches with modifications on your example so you can reproduce the error easily:
Checkout this one to reproduce it : https://github.com/palcalde/JTCalendar/tree/noFix
Checkout this one to see how the fix works: https://github.com/palcalde/JTCalendar/tree/withFix

Hope this helps.