### PR TITLE
-- adding menu item index to prepare prepareMenuItemView

### DIFF
--- a/Example/Example/CustomViewController.m
+++ b/Example/Example/CustomViewController.m
@@ -39,7 +39,7 @@
     // Generate random events sort by date using a dateformatter for the demonstration
     [self createRandomEvents];
     
-    _calendarMenuView.contentRatio = .75;
+    _calendarMenuView.contentRatio = 0.5;
     _calendarManager.settings.weekDayFormat = JTCalendarWeekDayFormatSingle;
     _calendarManager.dateHelper.calendar.locale = [NSLocale localeWithLocaleIdentifier:@"fr_FR"];
     
@@ -128,7 +128,7 @@
     return label;
 }
 
-- (void)calendar:(JTCalendarManager *)calendar prepareMenuItemView:(UILabel *)menuItemView date:(NSDate *)date
+- (void)calendar:(JTCalendarManager *)calendar prepareMenuItemView:(UILabel *)menuItemView date:(NSDate *)date itemIndex:(NSUInteger)index
 {
     static NSDateFormatter *dateFormatter;
     if(!dateFormatter){
@@ -137,6 +137,12 @@
         
         dateFormatter.locale = _calendarManager.dateHelper.calendar.locale;
         dateFormatter.timeZone = _calendarManager.dateHelper.calendar.timeZone;
+    }
+    
+    if (index == 1){
+        menuItemView.textColor = [UIColor blackColor];
+    }else{
+        menuItemView.textColor = [UIColor grayColor];
     }
     
     menuItemView.text = [dateFormatter stringFromDate:date];

--- a/JTCalendar/JTCalendarDelegate.h
+++ b/JTCalendar/JTCalendarDelegate.h
@@ -32,7 +32,7 @@
  * Used to customize the menuItemView.
  * Set text attribute to the name of the month by default.
  */
-- (void)calendar:(JTCalendarManager *)calendar prepareMenuItemView:(UIView *)menuItemView date:(NSDate *)date;
+- (void)calendar:(JTCalendarManager *)calendar prepareMenuItemView:(UIView *)menuItemView date:(NSDate *)date itemIndex:(NSUInteger)index;
 
 
 // Content view

--- a/JTCalendar/Managers/JTCalendarDelegateManager.h
+++ b/JTCalendar/Managers/JTCalendarDelegateManager.h
@@ -18,7 +18,7 @@
 // Menu view
 
 - (UIView *)buildMenuItemView;
-- (void)prepareMenuItemView:(UIView *)menuItemView date:(NSDate *)date;
+- (void)prepareMenuItemView:(UIView *)menuItemView date:(NSDate *)date itemIndex:(NSUInteger)index;
 
 // Content view
 

--- a/JTCalendar/Managers/JTCalendarDelegateManager.m
+++ b/JTCalendar/Managers/JTCalendarDelegateManager.m
@@ -30,10 +30,10 @@
     return label;
 }
 
-- (void)prepareMenuItemView:(UIView *)menuItemView date:(NSDate *)date
+- (void)prepareMenuItemView:(UIView *)menuItemView date:(NSDate *)date itemIndex:(NSUInteger)index
 {
-    if(_manager.delegate && [_manager.delegate respondsToSelector:@selector(calendar:prepareMenuItemView:date:)]){
-        [_manager.delegate calendar:self.manager prepareMenuItemView:menuItemView date:date];
+    if(_manager.delegate && [_manager.delegate respondsToSelector:@selector(calendar:prepareMenuItemView:date:itemIndex:)]){
+        [_manager.delegate calendar:self.manager prepareMenuItemView:menuItemView date:date itemIndex:index];
         return;
     }
     

--- a/JTCalendar/Views/JTCalendarMenuView.m
+++ b/JTCalendar/Views/JTCalendarMenuView.m
@@ -181,9 +181,9 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
         [_scrollView addSubview:_rightView];
     }
     
-    [_manager.delegateManager prepareMenuItemView:_leftView date:previousDate];
-    [_manager.delegateManager prepareMenuItemView:_centerView date:currentDate];
-    [_manager.delegateManager prepareMenuItemView:_rightView date:nextDate];
+    [_manager.delegateManager prepareMenuItemView:_leftView date:previousDate itemIndex:0];
+    [_manager.delegateManager prepareMenuItemView:_centerView date:currentDate itemIndex:1];
+    [_manager.delegateManager prepareMenuItemView:_rightView date:nextDate itemIndex:2];
     
     BOOL haveLeftPage = [_manager.delegateManager canDisplayPageWithDate:previousDate];
     BOOL haveRightPage = [_manager.delegateManager canDisplayPageWithDate:nextDate];


### PR DESCRIPTION
Hey, thanks for this interesting library, I found it a lot useful for a project where I am working right now. Btw

I just added an index to prepareMenuItem protocol method to manage UI states of the menu item views when selected. I know that the ``JTCalendarMenuView`` is  a class that can easily customized, but I think this modification is useful for all subclassing of ``JTCalendarMenuView`` or whatever class that implements the ``JTMenu`` protocol. Always is gonna be a index change for the menu item elements.

Also, I put an example of that in the CustomViewController. So take a look and let me know if I should change something!

Have a nice weekend! 
