### PR TITLE
Make it clearer that 'date' must be set last on JTCalendarManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Your `UIViewController` have to implement `JTCalendarDelegate`, all methods are 
     
     [_calendarManager setMenuView:_calendarMenuView];
     [_calendarManager setContentView:_calendarContentView];
-    [_calendarManager setDate:[NSDate date]];
+    [_calendarManager setDate:[NSDate date]]; // 'date' must be set after 'menuView' and 'contentView'
 }
 
 @end


### PR DESCRIPTION
It apparently doesn't work if the date is set before the menu view and the content view. I was stuck on this for a while :)

Maybe there could be an NSAssert on the content view when assigning the date ?