### PR TITLE
Add support for day format without leading zero

### DIFF
--- a/JTCalendar/JTCalendarSettings.h
+++ b/JTCalendar/JTCalendarSettings.h
@@ -34,6 +34,11 @@ typedef NS_ENUM(NSInteger, JTCalendarWeekDayFormat) {
 @property (nonatomic) JTCalendarWeekDayFormat weekDayFormat;
 
 
+// Day view
+
+@property (nonatomic) BOOL zeroPaddedDayFormat;
+
+
 // Use for override
 - (void)commonInit;
 

--- a/JTCalendar/JTCalendarSettings.m
+++ b/JTCalendar/JTCalendarSettings.m
@@ -27,6 +27,7 @@
     _pageViewNumberOfWeeks = 6;
     _pageViewHaveWeekDaysView = YES;
     _weekDayFormat = JTCalendarWeekDayFormatShort;
+    _zeroPaddedDayFormat = YES;
     _weekModeEnabled = NO;
     _pageViewWeekModeNumberOfWeeks = 1;
 }

--- a/JTCalendar/Views/JTCalendarDayView.m
+++ b/JTCalendar/Views/JTCalendarDayView.m
@@ -116,15 +116,19 @@
 
 - (void)reload
 {
+    _textLabel.text = [self.dateFormatter stringFromDate:_date];
+
+    [_manager.delegateManager prepareDayView:self];
+}
+
+- (NSDateFormatter *)dateFormatter
+{
     static NSDateFormatter *dateFormatter = nil;
     if(!dateFormatter){
         dateFormatter = [_manager.dateHelper createDateFormatter];
         [dateFormatter setDateFormat:@"dd"];
     }
-    
-    _textLabel.text = [dateFormatter stringFromDate:_date];
-        
-    [_manager.delegateManager prepareDayView:self];
+    return dateFormatter;
 }
 
 - (void)didTouch

--- a/JTCalendar/Views/JTCalendarDayView.m
+++ b/JTCalendar/Views/JTCalendarDayView.m
@@ -126,9 +126,14 @@
     static NSDateFormatter *dateFormatter = nil;
     if(!dateFormatter){
         dateFormatter = [_manager.dateHelper createDateFormatter];
-        [dateFormatter setDateFormat:@"dd"];
+        [dateFormatter setDateFormat:self.dayFormat];
     }
     return dateFormatter;
+}
+
+- (NSString *)dayFormat
+{
+    return self.manager.settings.zeroPaddedDayFormat ? @"dd" : @"d";
 }
 
 - (void)didTouch


### PR DESCRIPTION
Format of the day of the month displayed by JTCalendarDayView can now be set without leading zero. Single digit days can be displayed as "1" instead of "01". This is usually the preferred format in the USA.

The date formatter's format is not directly customizable because only the 2 formats "dd" and "d" make sense in this context.

The default behaviour (zero-padded format) has not changed. However one drawback of the current implementation is that it's not possible to toggle between the 2 formats once the calendar has been rendered. This is because, for performance reasons, the date formatter is cached in a static variable instead of being recreated every time. It's unlikely that someone would want to switch between the 2 formats on the fly so it should be good enough for now.