### PR TITLE
To add extra view on the top of JTCalendarMenuView

### DIFF
--- a/JTCalendar/Views/JTCalendarMenuView.h
+++ b/JTCalendar/Views/JTCalendarMenuView.h
@@ -22,4 +22,5 @@
  */
 - (void)commonInit;
 
+- (UIView*)centerView;
 @end

--- a/JTCalendar/Views/JTCalendarMenuView.h
+++ b/JTCalendar/Views/JTCalendarMenuView.h
@@ -22,5 +22,5 @@
  */
 - (void)commonInit;
 
-- (UIView*)centerView;
+- (CGSize)centerTextSize;
 @end

--- a/JTCalendar/Views/JTCalendarMenuView.m
+++ b/JTCalendar/Views/JTCalendarMenuView.m
@@ -73,9 +73,14 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
     }
 }
 
-- (UIView*)centerView
+- (CGSize)centerTextSize
 {
-	return _centerView;
+	if (_centerView && [_centerView isKindOfClass:[UILabel class]])
+	{
+       UILabel* label = (UILabel*)_centerView;
+	   return [label.text sizeWithAttributes:@{NSFontAttributeName:[label font]}];
+	}
+	return CGSizeZero;
 }
 
 - (void)layoutSubviews

--- a/JTCalendar/Views/JTCalendarMenuView.m
+++ b/JTCalendar/Views/JTCalendarMenuView.m
@@ -73,6 +73,11 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
     }
 }
 
+- (UIView*)centerView
+{
+	return _centerView;
+}
+
 - (void)layoutSubviews
 {
     [super layoutSubviews];


### PR DESCRIPTION
With this return value, developers can add any decoration view for JTCalendarMenuView. For example, I would like to add an arrow icon just beside the date text.