### PR TITLE
Making it easier to track the visible start and end dates of a calendar page.

### DIFF
--- a/JTCalendar/Protocols/JTCalendarPage.h
+++ b/JTCalendar/Protocols/JTCalendarPage.h
@@ -16,6 +16,9 @@
 - (NSDate *)date;
 - (void)setDate:(NSDate *)date;
 
+- (NSDate *)startDate;
+- (NSDate *)endDate;
+
 - (void)reload;
 
 @end

--- a/JTCalendar/Protocols/JTContent.h
+++ b/JTCalendar/Protocols/JTContent.h
@@ -16,6 +16,9 @@
 - (NSDate *)date;
 - (void)setDate:(NSDate *)date;
 
+- (NSDate *)visibleStartDate;
+- (NSDate *)visibleEndDate;
+
 - (void)loadPreviousPage;
 - (void)loadNextPage;
 

--- a/JTCalendar/Views/JTCalendarPageView.h
+++ b/JTCalendar/Views/JTCalendarPageView.h
@@ -13,6 +13,9 @@
 
 @property (nonatomic, weak) JTCalendarManager *manager;
 
+@property (nonatomic, readonly) NSDate *startDate;
+@property (nonatomic, readonly) NSDate *endDate;
+
 @property (nonatomic) NSDate *date;
 
 /*!

--- a/JTCalendar/Views/JTCalendarPageView.m
+++ b/JTCalendar/Views/JTCalendarPageView.m
@@ -96,6 +96,8 @@
         weekDate = [_manager.dateHelper firstWeekDayOfMonth:_date];
     }
     
+    _startDate = weekDate;
+    
     for(NSUInteger i = 0; i < _numberOfWeeksDisplayed; i++){
         UIView<JTCalendarWeek> *weekView = _weeksViews[i];
         
@@ -111,6 +113,8 @@
         
         weekDate = [_manager.dateHelper addToDate:weekDate weeks:1];
     }
+    
+    _endDate = [_manager.dateHelper addToDate:weekDate days:-1];
     
     for(NSUInteger i = _numberOfWeeksDisplayed; i < MAX_WEEKS_BY_MONTH; i++){
         UIView<JTCalendarWeek> *weekView = _weeksViews[i];

--- a/JTCalendar/Views/JTHorizontalCalendarView.h
+++ b/JTCalendar/Views/JTHorizontalCalendarView.h
@@ -14,6 +14,8 @@
 @property (nonatomic, weak) JTCalendarManager *manager;
 
 @property (nonatomic) NSDate *date;
+@property (nonatomic, readonly) NSDate *visibleStartDate;
+@property (nonatomic, readonly) NSDate *visibleEndDate;
 
 /*!
  * Must be call if override the class

--- a/JTCalendar/Views/JTHorizontalCalendarView.m
+++ b/JTCalendar/Views/JTHorizontalCalendarView.m
@@ -349,6 +349,14 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
     [self repositionViews];
 }
 
+- (NSDate *)visibleStartDate {
+    return _centerView.startDate;
+}
+
+- (NSDate *)visibleEndDate {
+    return _centerView.endDate;
+}
+
 - (void)setManager:(JTCalendarManager *)manager
 {
     self->_manager = manager;

--- a/JTCalendar/Views/JTVerticalCalendarView.h
+++ b/JTCalendar/Views/JTVerticalCalendarView.h
@@ -14,6 +14,8 @@
 @property (nonatomic, weak) JTCalendarManager *manager;
 
 @property (nonatomic) NSDate *date;
+@property (nonatomic, readonly) NSDate *visibleStartDate;
+@property (nonatomic, readonly) NSDate *visibleEndDate;
 
 /*!
  * Must be call if override the class

--- a/JTCalendar/Views/JTVerticalCalendarView.m
+++ b/JTCalendar/Views/JTVerticalCalendarView.m
@@ -349,6 +349,14 @@ typedef NS_ENUM(NSInteger, JTCalendarPageMode) {
     [self repositionViews];
 }
 
+- (NSDate *)visibleStartDate {
+    return _centerView.startDate;
+}
+
+- (NSDate *)visibleEndDate {
+    return _centerView.endDate;
+}
+
 - (void)setManager:(JTCalendarManager *)manager
 {
     self->_manager = manager;


### PR DESCRIPTION
This makes it easier to ask the calendar what the current visible date ranges are per page.