### PR TITLE
Change [JTCalendarManager init] to accept locale and timezone

### DIFF
--- a/Example/Example/CustomViewController.m
+++ b/Example/Example/CustomViewController.m
@@ -33,7 +33,7 @@
 {
     [super viewDidLoad];
     
-    _calendarManager = [JTCalendarManager new];
+    _calendarManager = [[JTCalendarManager alloc] initWithLocale:[NSLocale localeWithLocaleIdentifier:@"fr_FR"] andTimeZone:[NSTimeZone localTimeZone]];
     _calendarManager.delegate = self;
     
     // Generate random events sort by date using a dateformatter for the demonstration
@@ -41,7 +41,6 @@
     
     _calendarMenuView.contentRatio = .75;
     _calendarManager.settings.weekDayFormat = JTCalendarWeekDayFormatSingle;
-    _calendarManager.dateHelper.calendar.locale = [NSLocale localeWithLocaleIdentifier:@"fr_FR"];
     
     [_calendarManager setMenuView:_calendarMenuView];
     [_calendarManager setContentView:_calendarContentView];

--- a/JTCalendar/JTCalendarManager.h
+++ b/JTCalendar/JTCalendarManager.h
@@ -33,8 +33,7 @@
 @property (nonatomic, readonly) JTCalendarDelegateManager *delegateManager;
 @property (nonatomic, readonly) JTCalendarScrollManager *scrollManager;
 
-// Use for override
-- (void)commonInit;
+- (instancetype)initWithLocale:(NSLocale *)locale andTimeZone:(NSTimeZone *)timeZone;
 
 - (NSDate *)date;
 - (void)setDate:(NSDate *)date;

--- a/JTCalendar/JTCalendarManager.m
+++ b/JTCalendar/JTCalendarManager.m
@@ -13,19 +13,23 @@
 
 - (instancetype)init
 {
+    return [self initWithLocale:[NSLocale currentLocale] andTimeZone:[NSTimeZone localTimeZone]];
+}
+
+- (instancetype)initWithLocale:(NSLocale *)locale andTimeZone:(NSTimeZone *)timeZone
+{
     self = [super init];
     if(!self){
         return nil;
     }
-    
-    [self commonInit];
+    [self commonInit:locale andTimeZone:timeZone];
     
     return self;
 }
 
-- (void)commonInit
+- (void)commonInit:(NSLocale *)locale andTimeZone:(NSTimeZone *)timeZone
 {
-    _dateHelper = [JTDateHelper new];
+    _dateHelper = [[JTDateHelper alloc] initWithLocale:locale andTimeZone:timeZone];
     _settings = [JTCalendarSettings new];
     
     _delegateManager = [JTCalendarDelegateManager new];

--- a/JTCalendar/JTDateHelper.h
+++ b/JTCalendar/JTDateHelper.h
@@ -9,6 +9,8 @@
 
 @interface JTDateHelper : NSObject
 
+- initWithLocale:(NSLocale *)locale andTimeZone:(NSTimeZone *)timeZone;
+
 - (NSCalendar *)calendar;
 - (NSDateFormatter *)createDateFormatter;
 

--- a/JTCalendar/JTDateHelper.m
+++ b/JTCalendar/JTDateHelper.m
@@ -9,11 +9,23 @@
 
 @interface JTDateHelper (){
     NSCalendar *_calendar;
+    NSLocale *_locale;
+    NSTimeZone *_timeZone;
 }
 
 @end
 
 @implementation JTDateHelper
+
+- (instancetype)initWithLocale:(NSLocale *)locale andTimeZone:(NSTimeZone *)timeZone
+{
+    self = [super init];
+    if (self) {
+        _locale = locale;
+        _timeZone = timeZone;
+    }
+    return self;
+}
 
 - (NSCalendar *)calendar
 {
@@ -23,8 +35,8 @@
 #else
         _calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
 #endif
-        _calendar.timeZone = [NSTimeZone localTimeZone];
-        _calendar.locale = [NSLocale currentLocale];
+        _calendar.timeZone = _timeZone;
+        _calendar.locale = _locale;
     }
     
     return _calendar;

--- a/README.md
+++ b/README.md
@@ -246,6 +246,13 @@ _calendarManager.dateHelper.calendar.timeZone = [NSTimeZone timeZoneWithAbbrevia
 _calendarManager.dateHelper.calendar.locale = [NSLocale localeWithLocaleIdentifier:@"fr_FR"];
 [_calendarManager reload];
 ```
+For changing locale and timeZone in Swift use:
+
+```swift
+let locale = Locale(identifier: "fr_FR")
+let timeZone = TimeZone.init(abbreviation: "CDT")
+calendarManager = JTCalendarManager(locale: locale, andTimeZone: timeZone)
+```
 
 ### Date comparaison
 


### PR DESCRIPTION
Unable to change localization using your advice by set calendar's locale. This happens only in Swift projects because compiler bridges NSCalendar to Calendar structs. 