### PR TITLE
Fix on certain devices, because the width or height appears as a floa…

### DIFF
--- a/JTCalendar/Views/JTCalendarWeekDayView.m
+++ b/JTCalendar/Views/JTCalendarWeekDayView.m
@@ -112,7 +112,7 @@
     CGFloat dayHeight = self.frame.size.height;
     
     for(UIView *dayView in _dayViews){
-        dayView.frame = CGRectMake(x, 0, dayWidth, dayHeight);
+        dayView.frame = CGRectMake(x, 0, ceil(dayWidth), ceil(dayHeight));
         x += dayWidth;
     }
 }


### PR DESCRIPTION
When I render a calendar view on the iPhone simulator, I see a black border around some views. Eeventually I found that when configured dayViews. Set it's width or height to floating point value, and the result was black edges around the view, but only on some devices.

It look like this.

<img width="388" alt="2018-06-21 3 31 20" src="https://user-images.githubusercontent.com/14148687/41704316-7c2238a2-7568-11e8-9483-e877e1ee08e7.png">
