### PR TITLE
add nullability annotations

### DIFF
--- a/JTCalendar/JTCalendarDelegate.h
+++ b/JTCalendar/JTCalendarDelegate.h
@@ -26,13 +26,13 @@
  * Provide a UIView, used as page for the menuView.
  * Return an instance of `UILabel` by default.
  */
-- (UIView *)calendarBuildMenuItemView:(JTCalendarManager *)calendar;
+- (UIView *_Nullable)calendarBuildMenuItemView:(JTCalendarManager *_Nullable)calendar;
 
 /*!
  * Used to customize the menuItemView.
  * Set text attribute to the name of the month by default.
  */
-- (void)calendar:(JTCalendarManager *)calendar prepareMenuItemView:(UIView *)menuItemView date:(NSDate *)date;
+- (void)calendar:(JTCalendarManager *_Nullable)calendar prepareMenuItemView:(UIView *_Nullable)menuItemView date:(NSDate *_Nullable)date;
 
 
 // Content view
@@ -42,35 +42,35 @@
  * Indicate if the calendar can go to this date.
  * Return `YES` by default.
  */
-- (BOOL)calendar:(JTCalendarManager *)calendar canDisplayPageWithDate:(NSDate *)date;
+- (BOOL)calendar:(JTCalendarManager *_Nullable)calendar canDisplayPageWithDate:(NSDate *_Nullable)date;
 
 /*!
  * Provide the date for the previous page.
  * Return 1 month before the current date by default.
  */
-- (NSDate *)calendar:(JTCalendarManager *)calendar dateForPreviousPageWithCurrentDate:(NSDate *)currentDate;
+- (NSDate *_Nullable)calendar:(JTCalendarManager *_Nullable)calendar dateForPreviousPageWithCurrentDate:(NSDate *_Nullable)currentDate;
 
 /*!
  * Provide the date for the next page.
  * Return 1 month after the current date by default.
  */
-- (NSDate *)calendar:(JTCalendarManager *)calendar dateForNextPageWithCurrentDate:(NSDate *)currentDate;
+- (NSDate *_Nullable)calendar:(JTCalendarManager *_Nullable)calendar dateForNextPageWithCurrentDate:(NSDate *_Nullable)currentDate;
 
 /*!
  * Indicate the previous page became the current page.
  */
-- (void)calendarDidLoadPreviousPage:(JTCalendarManager *)calendar;
+- (void)calendarDidLoadPreviousPage:(JTCalendarManager *_Nullable)calendar;
 
 /*!
  * Indicate the next page became the current page.
  */
-- (void)calendarDidLoadNextPage:(JTCalendarManager *)calendar;
+- (void)calendarDidLoadNextPage:(JTCalendarManager *_Nullable)calendar;
 
 /*!
  * Provide a view conforming to `JTCalendarPage` protocol, used as page for the contentView.
  * Return an instance of `JTCalendarPageView` by default.
  */
-- (UIView<JTCalendarPage> *)calendarBuildPageView:(JTCalendarManager *)calendar;
+- (UIView<JTCalendarPage> *_Nullable)calendarBuildPageView:(JTCalendarManager *_Nullable)calendar;
 
 
 // Page view
@@ -80,13 +80,13 @@
  * Provide a view conforming to `JTCalendarWeekDay` protocol.
  * Return an instance of `JTCalendarWeekDayView` by default.
  */
-- (UIView<JTCalendarWeekDay> *)calendarBuildWeekDayView:(JTCalendarManager *)calendar;
+- (UIView<JTCalendarWeekDay> *_Nullable)calendarBuildWeekDayView:(JTCalendarManager *_Nullable)calendar;
 
 /*!
  * Provide a view conforming to `JTCalendarWeek` protocol.
  * Return an instance of `JTCalendarWeekView` by default.
  */
-- (UIView<JTCalendarWeek> *)calendarBuildWeekView:(JTCalendarManager *)calendar;
+- (UIView<JTCalendarWeek> *_Nullable)calendarBuildWeekView:(JTCalendarManager *_Nullable)calendar;
 
 
 // Week view
@@ -96,7 +96,7 @@
  * Provide a view conforming to `JTCalendarDay` protocol.
  * Return an instance of `JTCalendarDayView` by default.
  */
-- (UIView<JTCalendarDay> *)calendarBuildDayView:(JTCalendarManager *)calendar;
+- (UIView<JTCalendarDay> *_Nullable)calendarBuildDayView:(JTCalendarManager *_Nullable)calendar;
 
 
 // Day view
@@ -105,11 +105,11 @@
 /*!
  * Used to customize the dayView.
  */
-- (void)calendar:(JTCalendarManager *)calendar prepareDayView:(UIView<JTCalendarDay> *)dayView;
+- (void)calendar:(JTCalendarManager *_Nullable)calendar prepareDayView:(UIView<JTCalendarDay> *_Nullable)dayView;
 
 /*!
  * Indicate the dayView just get touched.
  */
-- (void)calendar:(JTCalendarManager *)calendar didTouchDayView:(UIView<JTCalendarDay> *)dayView;
+- (void)calendar:(JTCalendarManager *_Nullable)calendar didTouchDayView:(UIView<JTCalendarDay> *_Nullable)dayView;
 
 @end

--- a/JTCalendar/JTCalendarManager.h
+++ b/JTCalendar/JTCalendarManager.h
@@ -20,23 +20,23 @@
 
 @interface JTCalendarManager : NSObject
 
-@property (nonatomic, weak) id<JTCalendarDelegate> delegate;
+@property (nonatomic, weak, nullable) id<JTCalendarDelegate> delegate;
 
-@property (nonatomic, weak) UIView<JTMenu> *menuView;
-@property (nonatomic, weak) UIScrollView<JTContent> *contentView;
+@property (nonatomic, weak) UIView<JTMenu> * _Nullable menuView;
+@property (nonatomic, weak) UIScrollView<JTContent> * _Nullable contentView;
 
-@property (nonatomic, readonly) JTDateHelper *dateHelper;
-@property (nonatomic, readonly) JTCalendarSettings *settings;
+@property (nonatomic, readonly) JTDateHelper * _Nullable dateHelper;
+@property (nonatomic, readonly) JTCalendarSettings * _Nullable settings;
 
 // Intern methods
 
-@property (nonatomic, readonly) JTCalendarDelegateManager *delegateManager;
-@property (nonatomic, readonly) JTCalendarScrollManager *scrollManager;
+@property (nonatomic, readonly) JTCalendarDelegateManager * _Nullable delegateManager;
+@property (nonatomic, readonly) JTCalendarScrollManager * _Nullable scrollManager;
 
-- (instancetype)initWithLocale:(NSLocale *)locale andTimeZone:(NSTimeZone *)timeZone;
+- (instancetype _Nullable )initWithLocale:(NSLocale *_Nullable)locale andTimeZone:(NSTimeZone *_Nullable)timeZone;
 
-- (NSDate *)date;
-- (void)setDate:(NSDate *)date;
+- (NSDate *_Nonnull)date;
+- (void)setDate:(NSDate *_Nullable)date;
 - (void)reload;
 
 


### PR DESCRIPTION
# Why i open PR
## Why nullability annotations need

In this day, Many iOS App Project build on Swift. But JTCalendar is not suitable for those. So, I want to fix it.

In the first step, add nullability annotations. Optional is very important in Swift. Specially extention Reactive struct for RxSwift. This PR is gonna help to Many Project on Swift.

# Work
I just add nullability annotations to few Method and Properties.