### PR TITLE
Fix for automatic week count rendering and calculation

### DIFF
--- a/JTCalendar/JTDateHelper.m
+++ b/JTCalendar/JTDateHelper.m
@@ -82,11 +82,10 @@
     NSDate *firstDay = [self firstDayOfMonth:date];
     NSDate *lastDay = [self lastDayOfMonth:date];
     
-    NSDateComponents *componentsA = [self.calendar components:NSCalendarUnitWeekOfYear fromDate:firstDay];
-    NSDateComponents *componentsB = [self.calendar components:NSCalendarUnitWeekOfYear fromDate:lastDay];
+    NSDateComponents *componentsA = [self.calendar components:NSCalendarUnitWeekOfMonth fromDate:firstDay];
+    NSDateComponents *componentsB = [self.calendar components:NSCalendarUnitWeekOfMonth fromDate:lastDay];
     
-    // weekOfYear may return 53 for the first week of the year
-    return (componentsB.weekOfYear - componentsA.weekOfYear + 52 + 1) % 52;
+    return (componentsB.NSCalendarUnitWeekOfMonth - componentsA.NSCalendarUnitWeekOfMonth + 1);
 }
 
 - (NSDate *)firstDayOfMonth:(NSDate *)date

--- a/JTCalendar/Views/JTCalendarPageView.m
+++ b/JTCalendar/Views/JTCalendarPageView.m
@@ -117,6 +117,12 @@
         
         weekView.hidden = YES;
     }
+    
+    /*
+     * Forces the view to re-render the height of each weekView
+     * adjusted for the new `_numberOfWeeksDisplayed`
+     */
+    [self setNeedsLayout];
 }
 
 - (void)layoutSubviews


### PR DESCRIPTION
I noticed certain number of weeks calculations were failing so I attempted a fix.

1. I moved the `JTDateHelper` method `numberOfWeeks:` to use `NSCalendarUnitWeekOfMonth` instead.
2. I added a call to `setNeedsLayout` in `JTCalendarPageView` to force the page to re-calculate the height of each week.

These two changes appear to resolve issues with the `numberOfWeeksDisplayed` set to `0`