### PR TITLE
Add ability to inject custom calendar with backward compatibility

### DIFF
--- a/JTCalendar/JTCalendarManager.h
+++ b/JTCalendar/JTCalendarManager.h
@@ -34,6 +34,7 @@
 @property (nonatomic, readonly) JTCalendarScrollManager * _Nullable scrollManager;
 
 - (instancetype _Nullable )initWithLocale:(NSLocale *_Nullable)locale andTimeZone:(NSTimeZone *_Nullable)timeZone;
+- (instancetype _Nullable )initWithCalendar:(NSCalendar *_Nonnull)calendar;
 
 - (NSDate *_Nonnull)date;
 - (void)setDate:(NSDate *_Nullable)date;

--- a/JTCalendar/JTCalendarManager.m
+++ b/JTCalendar/JTCalendarManager.m
@@ -27,9 +27,24 @@
     return self;
 }
 
+- (instancetype)initWithCalendar:(NSCalendar*)calendar
+{
+    self = [super init];
+    if(!self){
+        return nil;
+    }
+    
+    _dateHelper = [[JTDateHelper alloc] initWithCalendar:calendar];
+    [self commonInit:calendar.locale andTimeZone:calendar.timeZone];
+    
+    return self;
+}
+
 - (void)commonInit:(NSLocale *)locale andTimeZone:(NSTimeZone *)timeZone
 {
-    _dateHelper = [[JTDateHelper alloc] initWithLocale:locale andTimeZone:timeZone];
+    if (_dateHelper == nil){
+        _dateHelper = [[JTDateHelper alloc] initWithLocale:locale andTimeZone:timeZone];
+    }
     _settings = [JTCalendarSettings new];
     
     _delegateManager = [JTCalendarDelegateManager new];

--- a/JTCalendar/JTDateHelper.h
+++ b/JTCalendar/JTDateHelper.h
@@ -10,6 +10,7 @@
 @interface JTDateHelper : NSObject
 
 - initWithLocale:(NSLocale *)locale andTimeZone:(NSTimeZone *)timeZone;
+- initWithCalendar:(NSCalendar *)calendar;
 
 - (NSCalendar *)calendar;
 - (NSDateFormatter *)createDateFormatter;

--- a/JTCalendar/JTDateHelper.m
+++ b/JTCalendar/JTDateHelper.m
@@ -27,6 +27,17 @@
     return self;
 }
 
+- (instancetype)initWithCalendar:(NSCalendar *)calendar
+{
+    self = [super init];
+    if (self) {
+        _calendar = calendar;
+        _locale = calendar.locale;
+        _timeZone = calendar.timeZone;
+    }
+    return self;
+}
+
 - (NSCalendar *)calendar
 {
     if(!_calendar){


### PR DESCRIPTION
Issue :
I needed to update few calendar's property e.g. firstWeekday, because JTDateHelper was returning non mutable calendar object , i was not able to do so.

Solution proposing
As JTDateHelper is having three instance variable , NSCalendar, NSLocale and NSTimeZone, but only 2 are available to inject.
There can always be a need to update some properties of NSCalendar and hence I added ability to inject full calendar object itself with maintaining the backward compatibility of current code.